### PR TITLE
Fixed lint issues with moving the code and comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ const config = createConfig('eslint', {
     'import/no-named-as-default-member': 'off',
     'import/no-self-import': 'off',
     'spaced-comment': ['error', 'always', { 'block': { 'exceptions': ['*'] } }],
+    'radix': 'off',
   },
 });
 

--- a/src/editors/Editor.test.jsx
+++ b/src/editors/Editor.test.jsx
@@ -12,7 +12,7 @@ jest.mock('./hooks', () => ({
 
 jest.mock('./containers/TextEditor', () => 'TextEditor');
 jest.mock('./containers/VideoEditor', () => 'VideoEditor');
-jest.mock('./containers/ProblemEditor/ProblemEditor', () => 'ProblemEditor');
+jest.mock('./containers/ProblemEditor', () => 'ProblemEditor');
 
 const initData = {
   blockId: 'block-v1:edX+DemoX+Demo_Course+type@html+block@030e35c4756a4ddc8d40b95fbbfff4d4',

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
@@ -12,6 +12,47 @@ import { actions, selectors } from '../../../../../data/redux';
 import { answerOptionProps } from '../../../../../data/services/cms/types';
 import { ProblemTypeKeys } from '../../../../../data/constants/problem';
 
+const Checker = ({
+  hasSingleAnswer, answer, setAnswer,
+}) => {
+  let CheckerType = Form.Checkbox;
+  if (hasSingleAnswer) {
+    CheckerType = Form.Radio;
+  }
+  return (
+    <CheckerType
+      className="pl-4 mt-3"
+      value={answer.id}
+      onChange={(e) => setAnswer({ correct: e.target.checked })}
+      defaultChecked={answer.correct}
+      checked={answer.correct}
+    >
+      {answer.id}
+    </CheckerType>
+  );
+};
+
+const FeedbackControl = ({
+  feedback, onChange, labelMessage, labelMessageBoldUnderline, key, answer, intl,
+}) => (
+  <Form.Group key={key}>
+    <Form.Label className="mb-3">
+      <FormattedMessage
+        {...labelMessage}
+        values={{
+          answerId: answer.id,
+          boldunderline: <b><u><FormattedMessage {...labelMessageBoldUnderline} /></u></b>,
+        }}
+      />
+    </Form.Label>
+    <Form.Control
+      placeholder={intl.formatMessage(messages.feedbackPlaceholder)}
+      value={feedback}
+      onChange={onChange}
+    />
+  </Form.Group>
+);
+
 export const AnswerOption = ({
   answer,
   hasSingleAnswer,
@@ -42,68 +83,36 @@ export const AnswerOption = ({
     setIsFeedbackVisible(open);
   };
 
-  const Checker = () => {
-    let CheckerType = Form.Checkbox;
-    if (hasSingleAnswer) {
-      CheckerType = Form.Radio;
-    }
-    return (
-      <CheckerType
-        className="pl-4 mt-3"
-        value={answer.id}
-        onChange={(e) => setAnswer({ correct: e.target.checked })}
-        defaultChecked={answer.correct}
-      >
-        {answer.id}
-      </CheckerType>
-    );
-  };
-
-  const feedbackControl = ({
-    feedback, onChange, labelMessage, labelMessageBoldUnderline, key,
-  }) => (
-    <Form.Group key={key}>
-      <Form.Label className="mb-3">
-        <FormattedMessage
-          {...labelMessage}
-          values={{
-            answerId: answer.id,
-            boldunderline: <b><u><FormattedMessage {...labelMessageBoldUnderline} /></u></b>,
-          }}
-        />
-      </Form.Label>
-      <Form.Control
-        placeholder={intl.formatMessage(messages.feedbackPlaceholder)}
-        value={feedback}
-        onChange={onChange}
-      />
-    </Form.Group>
-  );
-
-  const displayFeedbackControl = () => {
+  const displayFeedbackControl = (answerObject) => {
     if (problemType !== ProblemTypeKeys.MULTISELECT) {
-      return feedbackControl({
-        key: `feedback-${answer.id}`,
-        feedback: answer.feedback,
+      return FeedbackControl({
+        key: `feedback-${answerObject.id}`,
+        feedback: answerObject.feedback,
         onChange: (e) => setAnswer({ feedback: e.target.value }),
         labelMessage: messages.selectedFeedbackLabel,
         labelMessageBoldUnderline: messages.selectedFeedbackLabelBoldUnderlineText,
+        answer: answerObject,
+        intl,
       });
     }
     return [
-      feedbackControl({
-        key: `selectedfeedback-${answer.id}`,
-        feedback: answer.selectedFeedback,
+      FeedbackControl({
+        key: `selectedfeedback-${answerObject.id}`,
+        feedback: answerObject.selectedFeedback,
         onChange: (e) => setAnswer({ selectedFeedback: e.target.value }),
         labelMessage: messages.selectedFeedbackLabel,
         labelMessageBoldUnderline: messages.selectedFeedbackLabelBoldUnderlineText,
+        answer: answerObject,
+        intl,
       }),
-      feedbackControl({
-        key: `unselectedfeedback-${answer.id}`,
-        feedback: answer.unselectedFeedback,
+      FeedbackControl({
+        key: `unselectedfeedback-${answerObject.id}`,
+        feedback: answerObject.unselectedFeedback,
         onChange: (e) => setAnswer({ unselectedFeedback: e.target.value }),
         labelMessage: messages.unSelectedFeedbackLabel,
         labelMessageBoldUnderline: messages.unSelectedFeedbackLabelBoldUnderlineText,
+        answer: answerObject,
+        intl,
       }),
     ];
   };
@@ -117,7 +126,11 @@ export const AnswerOption = ({
       <Row className="my-2">
 
         <Col xs={1}>
-          <Checker />
+          <Checker
+            hasSingleAnswer={hasSingleAnswer}
+            answer={answer}
+            setAnswer={setAnswer}
+          />
         </Col>
 
         <Col xs={10}>
@@ -131,7 +144,7 @@ export const AnswerOption = ({
 
           <Collapsible.Body>
             <div className="bg-dark-100 p-4 mt-3">
-              {displayFeedbackControl()}
+              {displayFeedbackControl(answer)}
             </div>
           </Collapsible.Body>
         </Col>
@@ -168,6 +181,22 @@ AnswerOption.propTypes = {
   deleteAnswer: PropTypes.func.isRequired,
   updateAnswer: PropTypes.func.isRequired,
   problemType: PropTypes.string.isRequired,
+};
+
+FeedbackControl.propTypes = {
+  feedback: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  labelMessage: PropTypes.string.isRequired,
+  labelMessageBoldUnderline: PropTypes.string.isRequired,
+  key: PropTypes.string.isRequired,
+  answer: answerOptionProps.isRequired,
+  intl: intlShape.isRequired,
+};
+
+Checker.propTypes = {
+  hasSingleAnswer: PropTypes.bool.isRequired,
+  answer: answerOptionProps.isRequired,
+  setAnswer: PropTypes.func.isRequired,
 };
 
 export const mapStateToProps = (state) => ({

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswersContainer.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswersContainer.jsx
@@ -43,6 +43,7 @@ export const AnswersContainer = ({
 AnswersContainer.propTypes = {
   problemType: PropTypes.string.isRequired,
   answers: PropTypes.arrayOf(answerOptionProps).isRequired,
+  addAnswer: PropTypes.func.isRequired,
 };
 
 export const mapStateToProps = (state) => ({

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/__snapshots__/AnswerOption.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/__snapshots__/AnswerOption.test.jsx.snap
@@ -12,7 +12,18 @@ exports[`AnswerOption render snapshot: renders correct option with feedback 1`] 
     <Col
       xs={1}
     >
-      <Checker />
+      <Checker
+        answer={
+          Object {
+            "correct": true,
+            "feedback": "some feedback",
+            "id": "A",
+            "title": "Answer 1",
+          }
+        }
+        hasSingleAnswer={false}
+        setAnswer={[Function]}
+      />
     </Col>
     <Col
       xs={10}
@@ -97,7 +108,19 @@ exports[`AnswerOption render snapshot: renders correct option with selected unse
     <Col
       xs={1}
     >
-      <Checker />
+      <Checker
+        answer={
+          Object {
+            "correct": true,
+            "id": "A",
+            "selectedFeedback": "selected feedback",
+            "title": "Answer 1",
+            "unselectedFeedback": "unselected feedback",
+          }
+        }
+        hasSingleAnswer={false}
+        setAnswer={[Function]}
+      />
     </Col>
     <Col
       xs={10}
@@ -114,7 +137,7 @@ exports[`AnswerOption render snapshot: renders correct option with selected unse
           className="bg-dark-100 p-4 mt-3"
         >
           <Form.Group
-            key="selectedfeedback-A"
+            key="feedback-A"
           >
             <Form.Label
               className="mb-3"
@@ -142,39 +165,6 @@ exports[`AnswerOption render snapshot: renders correct option with selected unse
             <Form.Control
               onChange={[Function]}
               placeholder="Feedback message"
-              value="selected feedback"
-            />
-          </Form.Group>
-          <Form.Group
-            key="unselectedfeedback-A"
-          >
-            <Form.Label
-              className="mb-3"
-            >
-              <FormattedMessage
-                defaultMessage="Show following feedback when {answerId} {boldunderline}:"
-                description="Label text for feedback if option is not selected"
-                id="authoring.answerwidget.feedback.unselected.label"
-                values={
-                  Object {
-                    "answerId": "A",
-                    "boldunderline": <b>
-                      <u>
-                        <FormattedMessage
-                          defaultMessage="is not selected"
-                          description="Bold & underlined text for feedback if option is not selected"
-                          id="authoring.answerwidget.feedback.unselected.label.boldunderline"
-                        />
-                      </u>
-                    </b>,
-                  }
-                }
-              />
-            </Form.Label>
-            <Form.Control
-              onChange={[Function]}
-              placeholder="Feedback message"
-              value="unselected feedback"
             />
           </Form.Group>
         </div>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hook.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hook.test.js
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { MockUseState } from '../../../../../../testUtils';
+import * as module from './hooks';
+
+jest.mock('react', () => {
+  const updateState = jest.fn();
+  return {
+    updateState,
+    useEffect: jest.fn(),
+    useState: jest.fn(val => ([{ state: val }, (newVal) => updateState({ val, newVal })])),
+  };
+});
+
+jest.mock('../../../../../data/redux', () => ({
+  actions: {
+    problem: {
+      deleteAnswer: (args) => ({ deleteAnswer: args }),
+      updateAnswer: (args) => ({ updateAnswer: args }),
+    },
+  },
+}));
+
+const state = new MockUseState(module);
+
+let output;
+const answerWithOnlyFeedback = {
+  id: 'A',
+  title: 'Answer 1',
+  correct: true,
+  feedback: 'some feedback',
+};
+
+describe('Answer Options Hooks', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+  describe('state hooks', () => {
+    state.testGetter(state.keys.isFeedbackVisible);
+  });
+  describe('prepareFeedback hook', () => {
+    beforeEach(() => { state.mock(); });
+    afterEach(() => { state.restore(); });
+    test('test default state is false', () => {
+      output = module.prepareFeedback(answerWithOnlyFeedback);
+      expect(output.isFeedbackVisible).toBeFalsy();
+    });
+    test('when useEffect triggers, isFeedbackVisible is set to true', () => {
+      const key = state.keys.isFeedbackVisible;
+      output = module.prepareFeedback(answerWithOnlyFeedback);
+      expect(state.setState[key]).not.toHaveBeenCalled();
+      const [cb, prereqs] = useEffect.mock.calls[0];
+      expect(prereqs[0]).toStrictEqual(answerWithOnlyFeedback);
+      cb();
+      expect(state.setState[key]).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+import { StrictDict } from '../../../../../utils';
+import * as module from './hooks';
+import { actions } from '../../../../../data/redux';
+
+export const state = StrictDict({
+  isFeedbackVisible: (val) => useState(val),
+});
+
+export const removeAnswer = ({ answer, dispatch }) => () => {
+  dispatch(actions.problem.deleteAnswer({ id: answer.id }));
+};
+
+export const setAnswer = ({ answer, hasSingleAnswer, dispatch }) => (payload) => {
+  dispatch(actions.problem.updateAnswer({ id: answer.id, hasSingleAnswer, ...payload }));
+};
+
+export const prepareFeedback = (answer) => {
+  const [isFeedbackVisible, setIsFeedbackVisible] = module.state.isFeedbackVisible(false);
+  useEffect(() => {
+    // Show feedback fields if feedback is present
+    const isVisible = !!answer.selectedFeedback || !!answer.unselectedFeedback || !!answer.feedback;
+    setIsFeedbackVisible(isVisible);
+  }, [answer]);
+
+  const toggleFeedback = (open) => {
+    // Do not allow to hide if feedback is added
+    if (!!answer.selectedFeedback || !!answer.unselectedFeedback || !!answer.feedback) {
+      setIsFeedbackVisible(true);
+      return;
+    }
+    setIsFeedbackVisible(open);
+  };
+  return {
+    isFeedbackVisible,
+    toggleFeedback,
+  };
+};
+
+export default {
+  state, removeAnswer, setAnswer, prepareFeedback,
+};

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/index.jsx
@@ -5,6 +5,7 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 import { ProblemTypes } from '../../../../../data/constants/problem';
 import AnswersContainer from './AnswersContainer';
+import './index.scss';
 
 // This widget should be connected, grab all answers from store, update them as needed.
 const AnswerWidget = ({
@@ -14,13 +15,13 @@ const AnswerWidget = ({
   const problemStaticData = ProblemTypes[problemType];
   return (
     <div>
-      <div>
-        <h1 className="problem-answer-title">
+      <div className="problem-answer">
+        <div className="problem-answer-title">
           <FormattedMessage {...messages.answerWidgetTitle} />
-        </h1>
-        <h3>
+        </div>
+        <div className="problem-answer-description">
           {problemStaticData.description}
-        </h3>
+        </div>
       </div>
       <AnswersContainer problemType={problemType} />
     </div>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/index.scss
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/index.scss
@@ -1,0 +1,11 @@
+.problem-answer {
+    padding: 12px;
+    color: #00262B;
+    .problem-answer-title {
+        font-weight: bold;
+    }
+
+    .problem-answer-description {
+        font-size: 0.9rem;
+    }
+}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/QuestionWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/QuestionWidget/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Editor } from '@tinymce/tinymce-react';
-import { useSelector, useDispatch, connect } from 'react-redux';
+import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 import * as hooks from '../../../hooks';
 import { selectors, actions } from '../../../../../data/redux';
@@ -31,6 +32,11 @@ export const QuestionWidget = ({
       </div>
     </div>
   );
+};
+
+QuestionWidget.propTypes = {
+  question: PropTypes.string.isRequired,
+  updateQuestion: PropTypes.func.isRequired,
 };
 
 export const mapStateToProps = (state) => ({

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/QuestionWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/QuestionWidget/messages.js
@@ -5,3 +5,5 @@ export const messages = {
     description: 'Question Title',
   },
 };
+
+export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/SettingsOption.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/SettingsOption.jsx
@@ -1,58 +1,58 @@
-import React, { useState } from 'react';
-import { Collapsible, Icon, Card, } from '@edx/paragon';
+import React from 'react';
+import { Collapsible, Icon, Card } from '@edx/paragon';
 import { KeyboardArrowUp, KeyboardArrowDown } from '@edx/paragon/icons';
 import PropTypes from 'prop-types';
 import { showFullCard } from './hooks';
 
 export const SettingsOption = ({
-    title,
-    summary,
-    children
+  title,
+  summary,
+  children,
 }) => {
-    const {isCardCollapsed, toggleCardCollapse} = showFullCard();
+  const { isCardCollapsed, toggleCardCollapse } = showFullCard();
 
-    return (
-        <Card>
-            <Card.Section className="settingsCardTitleSection">
-                <Collapsible.Advanced
-                    open={isCardCollapsed}
-                    onToggle={toggleCardCollapse}
-                >
-                    <Collapsible.Trigger className="collapsible-trigger d-flex">
-                        <span className="flex-grow-1">{title}</span>
-                        <Collapsible.Visible whenClosed>
-                            <Icon src={KeyboardArrowDown} />
-                        </Collapsible.Visible>
-                        <Collapsible.Visible whenOpen>
-                            <Icon src={KeyboardArrowUp} />
-                        </Collapsible.Visible>
-                    </Collapsible.Trigger>
-                </Collapsible.Advanced>
-            </Card.Section>
-            <Card.Section>
-                <Collapsible.Advanced
-                    open={!isCardCollapsed}
-                >
-                    <Collapsible.Body className="collapsible-body">
-                        <span>{summary}</span>
-                    </Collapsible.Body>
-                </Collapsible.Advanced>
-                <Collapsible.Advanced
-                    open={isCardCollapsed}
-                >
-                    <Collapsible.Body className="collapsible-body">
-                        {children}
-                    </Collapsible.Body>
-                </Collapsible.Advanced>
-            </Card.Section>
-        </Card>
-    )
-}
+  return (
+    <Card>
+      <Card.Section className="settingsCardTitleSection">
+        <Collapsible.Advanced
+          open={isCardCollapsed}
+          onToggle={toggleCardCollapse}
+        >
+          <Collapsible.Trigger className="collapsible-trigger d-flex">
+            <span className="flex-grow-1">{title}</span>
+            <Collapsible.Visible whenClosed>
+              <Icon src={KeyboardArrowDown} />
+            </Collapsible.Visible>
+            <Collapsible.Visible whenOpen>
+              <Icon src={KeyboardArrowUp} />
+            </Collapsible.Visible>
+          </Collapsible.Trigger>
+        </Collapsible.Advanced>
+      </Card.Section>
+      <Card.Section>
+        <Collapsible.Advanced
+          open={!isCardCollapsed}
+        >
+          <Collapsible.Body className="collapsible-body">
+            <span>{summary}</span>
+          </Collapsible.Body>
+        </Collapsible.Advanced>
+        <Collapsible.Advanced
+          open={isCardCollapsed}
+        >
+          <Collapsible.Body className="collapsible-body">
+            {children}
+          </Collapsible.Body>
+        </Collapsible.Advanced>
+      </Card.Section>
+    </Card>
+  );
+};
 
 SettingsOption.propTypes = {
-    title: PropTypes.string.isRequired,
-    summary: PropTypes.string.isRequired,
-    children: PropTypes.node.isRequired,
+  title: PropTypes.string.isRequired,
+  summary: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 export default SettingsOption;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/SettingsOption.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/SettingsOption.test.jsx
@@ -2,17 +2,11 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import SettingsOption from './SettingsOption';
 
-
 describe('SettingsOption', () => {
-
-  const props = {
-    title: "Settings Option Title",
-    summary: "Settings Option Summary",
-  };
   describe('render', () => {
     const testContent = (<h1>My test content</h1>);
     test('snapshot: renders correct', () => {
-      expect(shallow(<SettingsOption title="Settings Option Title" summary="Settings Option Summary" >{testContent}</SettingsOption>)).toMatchSnapshot();
+      expect(shallow(<SettingsOption title="Settings Option Title" summary="Settings Option Summary">{testContent}</SettingsOption>)).toMatchSnapshot();
     });
   });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -3,11 +3,13 @@ import { useState, useEffect } from 'react';
 import _ from 'lodash-es';
 import * as module from './hooks';
 import messages from './messages';
+import { ShowAnswerTypesKeys } from '../../../../../data/constants/problem';
 
 export const state = {
   showAdvanced: (val) => useState(val),
   cardCollapsed: (val) => useState(val),
   summary: (val) => useState(val),
+  showAttempts: (val) => useState(val),
 };
 
 export const showAdvancedSettingsCards = () => {
@@ -137,8 +139,21 @@ export const scoringCardHooks = (scoring, updateSettings) => {
 };
 
 export const showAnswerCardHooks = (showAnswer, updateSettings) => {
+  const [showAttempts, setShowAttempts] = module.state.showAttempts(false);
+  const numberOfAttemptsChoice = [
+    ShowAnswerTypesKeys.AFTER_SOME_NUMBER_OF_ATTEMPTS,
+    ShowAnswerTypesKeys.AFTER_ALL_ATTEMPTS,
+    ShowAnswerTypesKeys.AFTER_ALL_ATTEMPTS_OR_CORRECT,
+  ];
+
+  useEffect(() => {
+    setShowAttempts(_.includes(numberOfAttemptsChoice, showAnswer.on));
+  }, [showAttempts]);
+
   const handleShowAnswerChange = (event) => {
-    updateSettings({ showAnswer: { ...showAnswer, on: event.target.value } });
+    const { value } = event.target;
+    setShowAttempts(_.includes(numberOfAttemptsChoice, value));
+    updateSettings({ showAnswer: { ...showAnswer, on: value } });
   };
 
   const handleAttemptsChange = (event) => {
@@ -152,6 +167,7 @@ export const showAnswerCardHooks = (showAnswer, updateSettings) => {
   return {
     handleShowAnswerChange,
     handleAttemptsChange,
+    showAttempts,
   };
 };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -1,184 +1,177 @@
 import { useState, useEffect } from 'react';
 
+import _ from 'lodash-es';
 import * as module from './hooks';
 import messages from './messages';
-import { actions } from '../../../../../data/redux';
-import _ from 'lodash-es';
 
 export const state = {
-    showAdvanced: (val) => useState(val),
-    cardCollapsed: (val) => useState(val),
-    summary: (val) => useState(val),
+  showAdvanced: (val) => useState(val),
+  cardCollapsed: (val) => useState(val),
+  summary: (val) => useState(val),
 };
 
 export const showAdvancedSettingsCards = () => {
-    const [isAdvancedCardsVisible, setIsAdvancedCardsVisible] = module.state.showAdvanced(false);
-    return {
-        isAdvancedCardsVisible,
-        showAdvancedCards: () => setIsAdvancedCardsVisible(true),
-    };
-}
+  const [isAdvancedCardsVisible, setIsAdvancedCardsVisible] = module.state.showAdvanced(false);
+  return {
+    isAdvancedCardsVisible,
+    showAdvancedCards: () => setIsAdvancedCardsVisible(true),
+  };
+};
 
 export const showFullCard = () => {
-    const [isCardCollapsed, setIsCardCollapsed] = module.state.cardCollapsed(false);
-    return {
-        isCardCollapsed,
-        toggleCardCollapse: () => setIsCardCollapsed(!isCardCollapsed),
-    };
-}
+  const [isCardCollapsed, setIsCardCollapsed] = module.state.cardCollapsed(false);
+  return {
+    isCardCollapsed,
+    toggleCardCollapse: () => setIsCardCollapsed(!isCardCollapsed),
+  };
+};
 
 export const hintsCardHooks = (hints, updateSettings) => {
-    const [summary, setSummary] = module.state.summary({ message: messages.noHintSummary, values: {} })
+  const [summary, setSummary] = module.state.summary({ message: messages.noHintSummary, values: {} });
 
-    useEffect(() => {
-        const hintsNumber = hints.length;
-        if (hintsNumber == 0) {
-            setSummary({ message: messages.noHintSummary, values: {} });
-        } else {
-            setSummary({ message: messages.hintSummary, values: { hint: hints[0].value, count: (hintsNumber - 1) } });
-        }
-    }, [hints]);
-
-    const handleAdd = () => {
-        let newId = 0
-        if (!_.isEmpty(hints)){
-            newId = Math.max(...hints.map(hint => hint.id)) + 1
-        }
-        const hint = { id: newId, value: "" }
-        hints = [...hints, hint]
-        updateSettings({ hints });
+  useEffect(() => {
+    const hintsNumber = hints.length;
+    if (hintsNumber === 0) {
+      setSummary({ message: messages.noHintSummary, values: {} });
+    } else {
+      setSummary({ message: messages.hintSummary, values: { hint: hints[0].value, count: (hintsNumber - 1) } });
     }
+  }, [hints]);
 
-
-    return {
-        summary,
-        handleAdd,
+  const handleAdd = () => {
+    let newId = 0;
+    if (!_.isEmpty(hints)) {
+      newId = Math.max(...hints.map(hint => hint.id)) + 1;
     }
-}
+    const hint = { id: newId, value: '' };
+    const modifiedHints = [...hints, hint];
+    updateSettings({ hints: modifiedHints });
+  };
+
+  return {
+    summary,
+    handleAdd,
+  };
+};
 
 export const hintsRowHooks = (id, hints, updateSettings) => {
+  const handleChange = (event) => {
+    const { value } = event.target;
+    const modifiedHints = hints.map(hint => {
+      if (hint.id === id) {
+        return { ...hint, value };
+      }
+      return hint;
+    });
+    updateSettings({ hints: modifiedHints });
+  };
 
-    const handleChange = (event) => {
-        const value = event.target.value
-        hints = hints.map(hint => {
-            if (hint.id === id) {
-                return { ...hint, value };
-            }
-            return hint;
-        });
-        updateSettings({ hints });
-    }
+  const handleDelete = () => {
+    const modifiedHints = hints.filter((hint) => (hint.id !== id));
+    updateSettings({ hints: modifiedHints });
+  };
 
-    const handleDelete = () => {
-        hints = hints.filter((hint) => (hint.id != id));
-        updateSettings({ hints });
-    }
-
-    return {
-        handleChange,
-        handleDelete,
-    }
-}
+  return {
+    handleChange,
+    handleDelete,
+  };
+};
 
 export const matlabCardHooks = (matLabApiKey, updateSettings) => {
-    const [summary, setSummary] = module.state.summary({ message: "", values: {}, intl: false })
+  const [summary, setSummary] = module.state.summary({ message: '', values: {}, intl: false });
 
-    useEffect(() => {
-        if (_.isEmpty(matLabApiKey)) {
-            setSummary({ message: messages.matlabNoKeySummary, values: {}, intl: true });
-        } else {
-            setSummary({ message: matLabApiKey, values: {}, intl: false });
-        }
-    }, [matLabApiKey])
-
-    const handleChange = (event) => {
-        updateSettings({ matLabApiKey: event.target.value });
+  useEffect(() => {
+    if (_.isEmpty(matLabApiKey)) {
+      setSummary({ message: messages.matlabNoKeySummary, values: {}, intl: true });
+    } else {
+      setSummary({ message: matLabApiKey, values: {}, intl: false });
     }
+  }, [matLabApiKey]);
 
-    return {
-        summary,
-        handleChange,
-    }
-}
+  const handleChange = (event) => {
+    updateSettings({ matLabApiKey: event.target.value });
+  };
+
+  return {
+    summary,
+    handleChange,
+  };
+};
 
 export const resetCardHooks = (updateSettings) => {
+  const setReset = (value) => {
+    updateSettings({ showResetButton: value });
+  };
 
-    const setReset = (value) => {
-        updateSettings({ showResetButton: value });
-    }
-
-    return {
-        setResetTrue: () => setReset(true),
-        setResetFalse: () => setReset(false),
-    }
-}
+  return {
+    setResetTrue: () => setReset(true),
+    setResetFalse: () => setReset(false),
+  };
+};
 
 export const scoringCardHooks = (scoring, updateSettings) => {
-
-    const handleMaxAttemptChange = (event) => {
-        let unlimitedAttempts = true;
-        let attemptNumber = parseInt(event.target.value);
-        if(_.isNaN(attemptNumber)) {
-            attemptNumber = 0;
-        }
-        if (attemptNumber > 0) {
-            unlimitedAttempts = false;
-        }
-        updateSettings({ scoring: { ...scoring, attempts: { number: attemptNumber, unlimited: unlimitedAttempts } } });
+  const handleMaxAttemptChange = (event) => {
+    let unlimitedAttempts = true;
+    let attemptNumber = parseInt(event.target.value);
+    if (_.isNaN(attemptNumber)) {
+      attemptNumber = 0;
     }
-
-    const handleWeightChange = (event) => {
-        let weight = parseFloat(event.target.value)
-        if(_.isNaN(weight)) {
-            weight = 0;
-        }
-        updateSettings({ scoring: { ...scoring, weight: weight } });
+    if (attemptNumber > 0) {
+      unlimitedAttempts = false;
     }
+    updateSettings({ scoring: { ...scoring, attempts: { number: attemptNumber, unlimited: unlimitedAttempts } } });
+  };
 
-    return {
-        handleMaxAttemptChange,
-        handleWeightChange,
+  const handleWeightChange = (event) => {
+    let weight = parseFloat(event.target.value);
+    if (_.isNaN(weight)) {
+      weight = 0;
     }
-}
+    updateSettings({ scoring: { ...scoring, weight } });
+  };
+
+  return {
+    handleMaxAttemptChange,
+    handleWeightChange,
+  };
+};
 
 export const showAnswerCardHooks = (showAnswer, updateSettings) => {
+  const handleShowAnswerChange = (event) => {
+    updateSettings({ showAnswer: { ...showAnswer, on: event.target.value } });
+  };
 
-    const handleShowAnswerChange = (event) => {
-        updateSettings({ showAnswer: { ...showAnswer, on: event.target.value } });
+  const handleAttemptsChange = (event) => {
+    let attempts = parseInt(event.target.value);
+    if (_.isNaN(attempts)) {
+      attempts = 0;
     }
+    updateSettings({ showAnswer: { ...showAnswer, afterAttempts: attempts } });
+  };
 
-    const handleAttemptsChange = (event) => {
-        let attempts = parseInt(event.target.value)
-        if(_.isNaN(attempts)){
-            attempts = 0;
-        }
-        updateSettings({ showAnswer: { ...showAnswer, afterAttempts: attempts } });
-    }
-
-    return {
-        handleShowAnswerChange,
-        handleAttemptsChange,
-    }
-}
+  return {
+    handleShowAnswerChange,
+    handleAttemptsChange,
+  };
+};
 
 export const timerCardHooks = (updateSettings) => ({
 
-    handleChange: (event) => {
-        let time = parseInt(event.target.value);
-        if(_.isNaN(time)){
-            time = 0;
-        }
-        updateSettings({ timeBetween: time });
+  handleChange: (event) => {
+    let time = parseInt(event.target.value);
+    if (_.isNaN(time)) {
+      time = 0;
     }
-})
+    updateSettings({ timeBetween: time });
+  },
+});
 
 export const typeRowHooks = (typeKey, updateField) => {
+  const onClick = () => {
+    updateField({ problemType: typeKey });
+  };
 
-    const onClick = () => {
-        updateField({ problemType: typeKey });
-    }
-
-    return {
-        onClick,
-    }
-}
+  return {
+    onClick,
+  };
+};

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -1,226 +1,227 @@
-import { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
-
-import { actions, selectors } from '../../../../../data/redux';
+import { useEffect } from 'react';
 import { MockUseState } from '../../../../../../testUtils';
 import messages from './messages';
 
 import * as hooks from './hooks';
 
-
 jest.mock('react', () => {
-    const updateState = jest.fn();
-    return {
-        updateState,
-        useEffect: jest.fn(),
-        useState: jest.fn(val => ([{ state: val }, (newVal) => updateState({ val, newVal })])),
-    };
+  const updateState = jest.fn();
+  return {
+    updateState,
+    useEffect: jest.fn(),
+    useState: jest.fn(val => ([{ state: val }, (newVal) => updateState({ val, newVal })])),
+  };
 });
 
-
 jest.mock('../../../../../data/redux', () => ({
-    actions: {
-        problem: {
-            updateSettings: (args) => ({ updateSettings: args }),
-            updateField: (args) => ({ updateField: args }),
-        },
+  actions: {
+    problem: {
+      updateSettings: (args) => ({ updateSettings: args }),
+      updateField: (args) => ({ updateField: args }),
     },
+  },
 }));
 
 const state = new MockUseState(hooks);
 
-
-
 describe('Problem settings hooks', () => {
-    let output;
-    let updateSettings;
+  let output;
+  let updateSettings;
+  beforeEach(() => {
+    updateSettings = jest.fn();
+    state.mock();
+  });
+  afterEach(() => {
+    state.restore();
+    useEffect.mockClear();
+  });
+  describe('Show advanced settings', () => {
     beforeEach(() => {
-        updateSettings = jest.fn()
-        state.mock();
+      output = hooks.showAdvancedSettingsCards();
     });
-    afterEach(() => { 
-        state.restore();
-        useEffect.mockClear();
+    test('test default state is false', () => {
+      expect(output.isAdvancedCardsVisible).toBeFalsy();
     });
-    describe('Show advanced settings', () => {
-        beforeEach(() => {
-            output = hooks.showAdvancedSettingsCards();
-        });
-        test('test default state is false', () => {
-            expect(output.isAdvancedCardsVisible).toBeFalsy();
-        });
-        test('test showAdvancedCards sets state to true', () => {
-            output.showAdvancedCards();
-            expect(state.setState[state.keys.showAdvanced]).toHaveBeenCalledWith(true);
-        });
+    test('test showAdvancedCards sets state to true', () => {
+      output.showAdvancedCards();
+      expect(state.setState[state.keys.showAdvanced]).toHaveBeenCalledWith(true);
     });
-    describe('Show full card', () => {
-        beforeEach(() => {
-            output = hooks.showFullCard();
-        });
-        test('test default state is false', () => {
-            expect(output.isCardCollapsed).toBeFalsy();
-        });
-        test('test toggleCardCollapse to true', () => {
-            output.toggleCardCollapse();
-            expect(state.setState[state.keys.cardCollapsed]).toHaveBeenCalledWith(true);
-        });
+  });
+  describe('Show full card', () => {
+    beforeEach(() => {
+      output = hooks.showFullCard();
     });
+    test('test default state is false', () => {
+      expect(output.isCardCollapsed).toBeFalsy();
+    });
+    test('test toggleCardCollapse to true', () => {
+      output.toggleCardCollapse();
+      expect(state.setState[state.keys.cardCollapsed]).toHaveBeenCalledWith(true);
+    });
+  });
 
-    describe('Hint card hooks', () => {
-        test('test useEffect triggers set hints summary no hint', () => {
-            const hints = [];
-            hooks.hintsCardHooks(hints, updateSettings);
-            expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
-            const [cb, prereqs] = useEffect.mock.calls[0];
-            expect(prereqs).toStrictEqual([[]]);
-            cb();
-            expect(state.setState[state.keys.summary]).toHaveBeenCalledWith({ "message": messages.noHintSummary, "values": {} });
-        })
-        test('test useEffect triggers set hints summary', () => {
-            const hints = [{ id: 1, value: "hint1" }];
-            output = hooks.hintsCardHooks(hints, updateSettings);
-            expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
-            const [cb, prereqs] = useEffect.mock.calls[0];
-            expect(prereqs).toStrictEqual([[{ id: 1, value: "hint1" }]]);
-            cb();
-            expect(state.setState[state.keys.summary]).toHaveBeenCalledWith({ message: messages.hintSummary, values: { hint: hints[0].value, count: (hints.length - 1) } });
-        })
-        test('test handleAdd triggers updateSettings', () => {
-            const hint1 = { id: 1, value: "hint1" }
-            const hint2 = { id: 2, value: "" }
-            const hints = [hint1];
-            output = hooks.hintsCardHooks(hints, updateSettings);
-            output.handleAdd();
-            expect(updateSettings).toHaveBeenCalledWith({ hints: [hint1, hint2] });
-        })
+  describe('Hint card hooks', () => {
+    test('test useEffect triggers set hints summary no hint', () => {
+      const hints = [];
+      hooks.hintsCardHooks(hints, updateSettings);
+      expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
+      const [cb, prereqs] = useEffect.mock.calls[0];
+      expect(prereqs).toStrictEqual([[]]);
+      cb();
+      expect(state.setState[state.keys.summary])
+        .toHaveBeenCalledWith({ message: messages.noHintSummary, values: {} });
     });
-
-    describe('Hint rows hooks', () => {
-        const hint1 = { id: 1, value: "hint1" }
-        const hint2 = { id: 2, value: "hint2" }
-        const value = "modified_hint"
-        const modified_hint = { id: 2, value: value }
-        const hints = [hint1, hint2];
-        beforeEach(() => {
-            output = hooks.hintsRowHooks(2, hints, updateSettings);
-        });
-        test('test handleChange', () => {
-            output.handleChange({ target: { value } });
-            expect(updateSettings).toHaveBeenCalledWith({ hints: [hint1, modified_hint] });
-        });
-        test('test handleDelete', () => {
-            output.handleDelete();
-            expect(updateSettings).toHaveBeenCalledWith({ hints: [hint1] });
+    test('test useEffect triggers set hints summary', () => {
+      const hints = [{ id: 1, value: 'hint1' }];
+      output = hooks.hintsCardHooks(hints, updateSettings);
+      expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
+      const [cb, prereqs] = useEffect.mock.calls[0];
+      expect(prereqs).toStrictEqual([[{ id: 1, value: 'hint1' }]]);
+      cb();
+      expect(state.setState[state.keys.summary])
+        .toHaveBeenCalledWith({
+          message: messages.hintSummary,
+          values: { hint: hints[0].value, count: (hints.length - 1) },
         });
     });
-
-    describe('Matlab card hooks', () => {
-        test('test useEffect triggers set summary', () => {
-            const api_key = "matlab_api_key";
-            hooks.matlabCardHooks(api_key, updateSettings);
-            expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
-            const [cb, prereqs] = useEffect.mock.calls[0];
-            expect(prereqs).toStrictEqual([api_key]);
-            cb();
-            expect(state.setState[state.keys.summary]).toHaveBeenCalledWith({ "message": api_key, "values": {}, "intl": false });
-        });
-        test('test useEffect triggers set summary no key', () => {
-            hooks.matlabCardHooks("", updateSettings);
-            expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
-            const [cb, prereqs] = useEffect.mock.calls[0];
-            expect(prereqs).toStrictEqual([""]);
-            cb();
-            expect(state.setState[state.keys.summary]).toHaveBeenCalledWith({ "message": messages.matlabNoKeySummary, "values": {}, "intl": true });
-        });
-        test('test handleChange', () => {
-            const api_key = "matlab_api_key";
-            const value = "new_matlab_api_key";
-            output = hooks.matlabCardHooks(api_key, updateSettings);
-            output.handleChange({ target: { value } });
-            expect(updateSettings).toHaveBeenCalledWith({ matLabApiKey: value });
-        });
+    test('test handleAdd triggers updateSettings', () => {
+      const hint1 = { id: 1, value: 'hint1' };
+      const hint2 = { id: 2, value: '' };
+      const hints = [hint1];
+      output = hooks.hintsCardHooks(hints, updateSettings);
+      output.handleAdd();
+      expect(updateSettings).toHaveBeenCalledWith({ hints: [hint1, hint2] });
     });
+  });
 
-    describe('Reset card hooks', () => {
-        beforeEach(() => {
-            output = hooks.resetCardHooks(updateSettings);
-        });
-        test('test setResetTrue', () => {
-            output.setResetTrue();
-            expect(updateSettings).toHaveBeenCalledWith({ showResetButton: true });
-        });
-        test('test setResetFalse', () => {
-            output.setResetFalse();
-            expect(updateSettings).toHaveBeenCalledWith({ showResetButton: false });
-        });
+  describe('Hint rows hooks', () => {
+    const hint1 = { id: 1, value: 'hint1' };
+    const hint2 = { id: 2, value: 'hint2' };
+    const value = 'modifiedHint';
+    const modifiedHint = { id: 2, value };
+    const hints = [hint1, hint2];
+    beforeEach(() => {
+      output = hooks.hintsRowHooks(2, hints, updateSettings);
     });
-
-    describe('Scoring card hooks', () => {
-        const scoring = {
-            weight: 1.5,
-            attempts: {
-                unlimited: false,
-                number: 5,
-            },
-        };
-        beforeEach(() => {
-            output = hooks.scoringCardHooks(scoring, updateSettings);
-        });
-        test('test handleMaxAttemptChange', () => {
-            const value = 6
-            output.handleMaxAttemptChange({ target: { value } });
-            expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: value, unlimited: false } } });
-        });
-        test('test handleMaxAttemptChange set attempts to zero', () => {
-            const value = 0
-            output.handleMaxAttemptChange({ target: { value } });
-            expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: value, unlimited: true } } });
-        });
-        test('test handleWeightChange', () => {
-            const value = 2
-            output.handleWeightChange({ target: { value } });
-            expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, weight: parseFloat(value) } });
-        });
+    test('test handleChange', () => {
+      output.handleChange({ target: { value } });
+      expect(updateSettings).toHaveBeenCalledWith({ hints: [hint1, modifiedHint] });
     });
-
-    describe('Show answer card hooks', () => {
-        const showAnswer = {
-            on: "after_attempts",
-            afterAttempts: 5,
-        };
-        beforeEach(() => {
-            output = hooks.showAnswerCardHooks(showAnswer, updateSettings);
-        });
-        test('test handleShowAnswerChange', () => {
-            const value = "always";
-            output.handleShowAnswerChange({ target: { value } });
-            expect(updateSettings).toHaveBeenCalledWith({ showAnswer: { ...showAnswer, on: value } });
-        });
-        test('test handleAttemptsChange', () => {
-            const value = 3;
-            output.handleAttemptsChange({ target: { value } });
-            expect(updateSettings).toHaveBeenCalledWith({ showAnswer: { ...showAnswer, afterAttempts: parseInt(value) } });
-        });
+    test('test handleDelete', () => {
+      output.handleDelete();
+      expect(updateSettings).toHaveBeenCalledWith({ hints: [hint1] });
     });
+  });
 
-    describe('Timer card hooks', () => {
-        test('test handleChange', () => {
-            output = hooks.timerCardHooks(updateSettings);
-            const value = 5;
-            output.handleChange({ target: { value } });
-            expect(updateSettings).toHaveBeenCalledWith({ timeBetween: value });
-        });
+  describe('Matlab card hooks', () => {
+    test('test useEffect triggers set summary', () => {
+      const apiKey = 'matlab_api_key';
+      hooks.matlabCardHooks(apiKey, updateSettings);
+      expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
+      const [cb, prereqs] = useEffect.mock.calls[0];
+      expect(prereqs).toStrictEqual([apiKey]);
+      cb();
+      expect(state.setState[state.keys.summary])
+        .toHaveBeenCalledWith({ message: apiKey, values: {}, intl: false });
     });
-
-    describe('Type row hooks', () => {
-        test('test onClick', () => {
-            const typekey = "TEXTINPUT"
-            const updateField = jest.fn()
-            output = hooks.typeRowHooks(typekey, updateField);
-            output.onClick();
-            expect(updateField).toHaveBeenCalledWith({ problemType: typekey });
-        });
+    test('test useEffect triggers set summary no key', () => {
+      hooks.matlabCardHooks('', updateSettings);
+      expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
+      const [cb, prereqs] = useEffect.mock.calls[0];
+      expect(prereqs).toStrictEqual(['']);
+      cb();
+      expect(state.setState[state.keys.summary])
+        .toHaveBeenCalledWith({ message: messages.matlabNoKeySummary, values: {}, intl: true });
     });
+    test('test handleChange', () => {
+      const apiKey = 'matlab_api_key';
+      const value = 'new_matlab_api_key';
+      output = hooks.matlabCardHooks(apiKey, updateSettings);
+      output.handleChange({ target: { value } });
+      expect(updateSettings).toHaveBeenCalledWith({ matLabApiKey: value });
+    });
+  });
 
-})
+  describe('Reset card hooks', () => {
+    beforeEach(() => {
+      output = hooks.resetCardHooks(updateSettings);
+    });
+    test('test setResetTrue', () => {
+      output.setResetTrue();
+      expect(updateSettings).toHaveBeenCalledWith({ showResetButton: true });
+    });
+    test('test setResetFalse', () => {
+      output.setResetFalse();
+      expect(updateSettings).toHaveBeenCalledWith({ showResetButton: false });
+    });
+  });
+
+  describe('Scoring card hooks', () => {
+    const scoring = {
+      weight: 1.5,
+      attempts: {
+        unlimited: false,
+        number: 5,
+      },
+    };
+    beforeEach(() => {
+      output = hooks.scoringCardHooks(scoring, updateSettings);
+    });
+    test('test handleMaxAttemptChange', () => {
+      const value = 6;
+      output.handleMaxAttemptChange({ target: { value } });
+      expect(updateSettings)
+        .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: value, unlimited: false } } });
+    });
+    test('test handleMaxAttemptChange set attempts to zero', () => {
+      const value = 0;
+      output.handleMaxAttemptChange({ target: { value } });
+      expect(updateSettings)
+        .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: value, unlimited: true } } });
+    });
+    test('test handleWeightChange', () => {
+      const value = 2;
+      output.handleWeightChange({ target: { value } });
+      expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, weight: parseFloat(value) } });
+    });
+  });
+
+  describe('Show answer card hooks', () => {
+    const showAnswer = {
+      on: 'after_attempts',
+      afterAttempts: 5,
+    };
+    beforeEach(() => {
+      output = hooks.showAnswerCardHooks(showAnswer, updateSettings);
+    });
+    test('test handleShowAnswerChange', () => {
+      const value = 'always';
+      output.handleShowAnswerChange({ target: { value } });
+      expect(updateSettings).toHaveBeenCalledWith({ showAnswer: { ...showAnswer, on: value } });
+    });
+    test('test handleAttemptsChange', () => {
+      const value = 3;
+      output.handleAttemptsChange({ target: { value } });
+      expect(updateSettings).toHaveBeenCalledWith({ showAnswer: { ...showAnswer, afterAttempts: parseInt(value) } });
+    });
+  });
+
+  describe('Timer card hooks', () => {
+    test('test handleChange', () => {
+      output = hooks.timerCardHooks(updateSettings);
+      const value = 5;
+      output.handleChange({ target: { value } });
+      expect(updateSettings).toHaveBeenCalledWith({ timeBetween: value });
+    });
+  });
+
+  describe('Type row hooks', () => {
+    test('test onClick', () => {
+      const typekey = 'TEXTINPUT';
+      const updateField = jest.fn();
+      output = hooks.typeRowHooks(typekey, updateField);
+      output.onClick();
+      expect(updateField).toHaveBeenCalledWith({ problemType: typekey });
+    });
+  });
+});

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { selectors, actions } from '../../../../../data/redux';
 import { injectIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 import { connect } from 'react-redux';
+import {
+  Button, Col, Collapsible, Container, Row,
+} from '@edx/paragon';
+import { selectors, actions } from '../../../../../data/redux';
 import ScoringCard from './settingsComponents/ScoringCard';
 import ShowAnswerCard from './settingsComponents/ShowAnswerCard';
 import HintsCard from './settingsComponents/HintsCard';
 import ResetCard from './settingsComponents/ResetCard';
 import MatlabCard from './settingsComponents/MatlabCard';
 import TimerCard from './settingsComponents/TimerCard';
-import { Button, Col, Collapsible, Container, Row } from '@edx/paragon';
 import TypeCard from './settingsComponents/TypeCard';
 import messages from './messages';
 import { showAdvancedSettingsCards } from './hooks';
@@ -34,18 +36,18 @@ export const SettingsWidget = ({
         <Container>
           <Row>
             <Col>
-              <Row className='my-2'>
+              <Row className="my-2">
                 <TypeCard problemType={problemType} updateField={updateField} />
               </Row>
-              <Row className='my-2'>
+              <Row className="my-2">
                 <ScoringCard scoring={settings.scoring} updateSettings={updateSettings} />
               </Row>
-              <Row className='mt-2'>
+              <Row className="mt-2">
                 <HintsCard hints={settings.hints} updateSettings={updateSettings} />
               </Row>
 
               <Row>
-                <Collapsible.Advanced open={!isAdvancedCardsVisible} >
+                <Collapsible.Advanced open={!isAdvancedCardsVisible}>
                   <Collapsible.Body className="collapsible-body">
                     <Button
                       className="my-3 ml-2"
@@ -59,18 +61,18 @@ export const SettingsWidget = ({
                 </Collapsible.Advanced>
               </Row>
 
-              <Collapsible.Advanced open={isAdvancedCardsVisible} >
+              <Collapsible.Advanced open={isAdvancedCardsVisible}>
                 <Collapsible.Body className="collapsible-body">
-                  <Row className='my-2'>
+                  <Row className="my-2">
                     <ShowAnswerCard showAnswer={settings.showAnswer} updateSettings={updateSettings} />
                   </Row>
-                  <Row className='my-2'>
+                  <Row className="my-2">
                     <ResetCard showResetButton={settings.showResetButton} updateSettings={updateSettings} />
                   </Row>
-                  <Row className='my-2'>
+                  <Row className="my-2">
                     <TimerCard timeBetween={settings.timeBetween} updateSettings={updateSettings} />
                   </Row>
-                  <Row className='my-2'>
+                  <Row className="my-2">
                     <MatlabCard matLabApiKey={settings.matLabApiKey} updateSettings={updateSettings} />
                   </Row>
                 </Collapsible.Body>
@@ -82,10 +84,14 @@ export const SettingsWidget = ({
 
     </div>
   );
-}
+};
 
 SettingsWidget.propTypes = {
   problemType: PropTypes.string.isRequired,
+  updateField: PropTypes.func.isRequired,
+  updateSettings: PropTypes.func.isRequired,
+  // eslint-disable-next-line
+  settings: PropTypes.any.isRequired,
 };
 
 const mapStateToProps = (state) => ({
@@ -95,6 +101,6 @@ const mapStateToProps = (state) => ({
 export const mapDispatchToProps = {
   updateSettings: actions.problem.updateSettings,
   updateField: actions.problem.updateField,
-}
+};
 
 export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(SettingsWidget));

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
@@ -6,57 +6,55 @@ import { ProblemTypeKeys } from '../../../../../data/constants/problem';
 import { actions } from '../../../../../data/redux';
 
 jest.mock('./hooks', () => ({
-    showAdvancedSettingsCards: jest.fn(),
+  showAdvancedSettingsCards: jest.fn(),
 }));
 
-
 describe('SettingsWidget', () => {
+  const props = {
+    problemType: ProblemTypeKeys.TEXTINPUT,
+    settings: {},
+  };
 
-    const props = {
-        problemType: ProblemTypeKeys.TEXTINPUT,
-        settings: {},
-    };
-
-    describe('behavior', () => {
-        it(' calls showAdvancedSettingsCards when initialized', () => {
-            const showAdvancedSettingsCardsProps = {
-                isAdvancedCardsVisible: false,
-                setResetTrue: jest.fn().mockName('showAdvancedSettingsCards.setResetTrue'),
-            };
-            showAdvancedSettingsCards.mockReturnValue(showAdvancedSettingsCardsProps);
-            shallow(<SettingsWidget {...props} />);
-            expect(showAdvancedSettingsCards).toHaveBeenCalledWith();
-        });
+  describe('behavior', () => {
+    it(' calls showAdvancedSettingsCards when initialized', () => {
+      const showAdvancedSettingsCardsProps = {
+        isAdvancedCardsVisible: false,
+        setResetTrue: jest.fn().mockName('showAdvancedSettingsCards.setResetTrue'),
+      };
+      showAdvancedSettingsCards.mockReturnValue(showAdvancedSettingsCardsProps);
+      shallow(<SettingsWidget {...props} />);
+      expect(showAdvancedSettingsCards).toHaveBeenCalledWith();
     });
+  });
 
-    describe('snapshot', () => {
-        test('snapshot: renders Settings widget page', () => {
-            const showAdvancedSettingsCardsProps = {
-                isAdvancedCardsVisible: false,
-                setResetTrue: jest.fn().mockName('showAdvancedSettingsCards.setResetTrue'),
-            };
-            showAdvancedSettingsCards.mockReturnValue(showAdvancedSettingsCardsProps);
-            expect(shallow(<SettingsWidget {...props} />)).toMatchSnapshot();
-        });
-        test('snapshot: renders Settings widget page advanced settings visible', () => {
-            const showAdvancedSettingsCardsProps = {
-                isAdvancedCardsVisible: true,
-                setResetTrue: jest.fn().mockName('showAdvancedSettingsCards.setResetTrue'),
-            };
-            showAdvancedSettingsCards.mockReturnValue(showAdvancedSettingsCardsProps);
-            expect(shallow(<SettingsWidget {...props} />)).toMatchSnapshot();
-        });
+  describe('snapshot', () => {
+    test('snapshot: renders Settings widget page', () => {
+      const showAdvancedSettingsCardsProps = {
+        isAdvancedCardsVisible: false,
+        setResetTrue: jest.fn().mockName('showAdvancedSettingsCards.setResetTrue'),
+      };
+      showAdvancedSettingsCards.mockReturnValue(showAdvancedSettingsCardsProps);
+      expect(shallow(<SettingsWidget {...props} />)).toMatchSnapshot();
     });
+    test('snapshot: renders Settings widget page advanced settings visible', () => {
+      const showAdvancedSettingsCardsProps = {
+        isAdvancedCardsVisible: true,
+        setResetTrue: jest.fn().mockName('showAdvancedSettingsCards.setResetTrue'),
+      };
+      showAdvancedSettingsCards.mockReturnValue(showAdvancedSettingsCardsProps);
+      expect(shallow(<SettingsWidget {...props} />)).toMatchSnapshot();
+    });
+  });
 
-    describe('mapDispatchToProps', () => {
-        test('updateSettings from actions.problem.updateSettings', () => {
-            expect(mapDispatchToProps.updateSettings).toEqual(actions.problem.updateSettings);
-        });
+  describe('mapDispatchToProps', () => {
+    test('updateSettings from actions.problem.updateSettings', () => {
+      expect(mapDispatchToProps.updateSettings).toEqual(actions.problem.updateSettings);
     });
+  });
 
-    describe('mapDispatchToProps', () => {
-        test('updateField from actions.problem.updateField', () => {
-            expect(mapDispatchToProps.updateField).toEqual(actions.problem.updateField);
-        });
+  describe('mapDispatchToProps', () => {
+    test('updateField from actions.problem.updateField', () => {
+      expect(mapDispatchToProps.updateField).toEqual(actions.problem.updateField);
     });
+  });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
@@ -1,154 +1,154 @@
 export const messages = {
-    settingsWidgetTitle: {
-        id: 'authoring.problemeditor.settings.settingsWidgetTitle',
-        defaultMessage: 'Settings',
-        description: 'Settings Title',
-    },
-    showAdvanceSettingsButtonText: {
-        id: 'authoring.problemeditor.settings.showAdvancedButton',
-        defaultMessage: 'Show advanced settings',
-        description: 'Button text to show advanced settings',
-    },
-    settingsDeleteIconAltText: {
-        id: 'authoring.problemeditor.settings.delete.icon.alt',
-        defaultMessage: 'Delete answer',
-        description: 'Alt text for delete icon',
-    },
-    advancedSettingsLinkText: {
-        id: 'authoring.problemeditor.settings.advancedSettingLink.text',
-        defaultMessage: 'Set a default value in advanced settings',
-        description: 'Advanced settings link text',
-    },
-    hintSettingTitle: {
-        id: 'authoring.problemeditor.settings.hint.title',
-        defaultMessage: 'Hints',
-        description: 'Hint settings card title',
-    },
-    hintInputLabel: {
-        id: 'authoring.problemeditor.settings.hint.inputLabel',
-        defaultMessage: 'Hint',
-        description: 'Hint text input label',
-    },
-    addHintButtonText: {
-        id: 'authoring.problemeditor.settings.hint.addHintButton',
-        defaultMessage: 'Add hint',
-        description: 'Add hint button text',
-    },
-    noHintSummary: {
-        id: 'authoring.problemeditor.settings.hint.noHintSummary',
-        defaultMessage: 'No Hints',
-        description: 'Summary text for no hints',
-    },
-    hintSummary: {
-        id: 'authoring.problemeditor.settings.hint.summary',
-        defaultMessage: "{hint} {count, plural, =0 {} other {(+# more)}}",
-        description: 'Summary text for hint settings',
-    },
-    matlabSettingTitle: {
-        id: 'authoring.problemeditor.settings.matlab.title',
-        defaultMessage: 'MATLAB API Key',
-        description: 'Matlab settings card title',
-    },
-    matlabSettingText1: {
-        id: 'authoring.problemeditor.settings.matlab.text.one',
-        defaultMessage: 'Enter the API key provided by MathWorks for accessing the MATLAB Hosted Service. This key is granted for exclusive use by this course for the specified duration.',
-        description: 'Matlab settings card text 1',
-    },
-    matlabSettingText2: {
-        id: 'authoring.problemeditor.settings.matlab.text.two',
-        defaultMessage: 'Please do not share the API key with other courses and notify MathWorks immediately if you believe the key is exposed or compromised. To obtain a key for your course, or to report an issue please contact',
-        description: 'Matlab settings card text 2',
-    },
-    matlabInputLabel: {
-        id: 'authoring.problemeditor.settings.matlab.inputLabel',
-        defaultMessage: 'API Key',
-        description: 'Matlab text input label',
-    },
-    matlabNoKeySummary: {
-        id: 'authoring.problemeditor.settings.matlab.noKeySummary',
-        defaultMessage: 'None',
-        description: 'Matlab no key summary',
-    },
-    resetSettingsTitle: {
-        id: 'authoring.problemeditor.settings.reset.title',
-        defaultMessage: 'Show reset option',
-        description: 'Reset settings card title',
-    },
-    resetSettingsTrue: {
-        id: 'authoring.problemeditor.settings.reset.true',
-        defaultMessage: 'True',
-        description: 'True option for reset',
-    },
-    resetSettingsFalse: {
-        id: 'authoring.problemeditor.settings.reset.false',
-        defaultMessage: 'False',
-        description: 'False option for reset',
-    },
-    resetSettingText: {
-        id: 'authoring.problemeditor.settings.reset.text',
-        defaultMessage: "Determines whether a 'Reset' button is shown so the user may reset their answer, generally for use in practice or formative assessments.",
-        description: 'Reset settings card text',
-    },
-    scoringSettingsTitle: {
-        id: 'authoring.problemeditor.settings.scoring.title',
-        defaultMessage: 'Scoring',
-        description: 'Scoring settings card title',
-    },
-    scoringAttemptsInputLabel: {
-        id: 'authoring.problemeditor.settings.scoring.attempts.inputLabel',
-        defaultMessage: 'Attempts',
-        description: 'Scoring attempts text input label',
-    },
-    scoringWeightInputLabel: {
-        id: 'authoring.problemeditor.settings.scoring.weight.inputLabel',
-        defaultMessage: 'Points',
-        description: 'Scoring weight input label',
-    },
-    scoringSummary: {
-        id: 'authoring.problemeditor.settings.scoring.summary',
-        defaultMessage: "{attempts, plural, =0 {Unlimited} other {#}} attempts - {weight, plural, =0 {Ungraded} other {# points}}",
-        description: 'Summary text for scoring settings',
-    },
-    showAnswerSettingsTitle: {
-        id: 'authoring.problemeditor.settings.showAnswer.title',
-        defaultMessage: 'Show answer',
-        description: 'Show Answer settings card title',
-    },
-    showAnswerAttemptsInputLabel: {
-        id: 'authoring.problemeditor.settings.showAnswer.attempts.inputLabel',
-        defaultMessage: 'Number of Attempts',
-        description: 'Show Answer attempts text input label',
-    },
-    showAnswerSettingText: {
-        id: 'authoring.problemeditor.settings.showAnswer.text',
-        defaultMessage: 'Define when learners can see the correct answer.',
-        description: 'Show Answer settings card text',
-    },
-    timerSettingsTitle: {
-        id: 'authoring.problemeditor.settings.timer.title',
-        defaultMessage: 'Time between attempts',
-        description: 'Timer settings card title',
-    },
-    timerSummary: {
-        id: 'authoring.problemeditor.settings.timer.summary',
-        defaultMessage: "{time} seconds",
-        description: 'Summary text for timer settings',
-    },
-    timerSettingText: {
-        id: 'authoring.problemeditor.settings.timer.text',
-        defaultMessage: 'Seconds a student must wait between submissions for a problem with multiple attempts.',
-        description: 'Timer settings card text',
-    },
-    timerInputLabel: {
-        id: 'authoring.problemeditor.settings.timer.inputLabel',
-        defaultMessage: 'Attempts',
-        description: 'Timer text input label',
-    },
-    typeSettingTitle: {
-        id: 'authoring.problemeditor.settings.type.title',
-        defaultMessage: 'Type',
-        description: 'Type settings card title',
-    }
+  settingsWidgetTitle: {
+    id: 'authoring.problemeditor.settings.settingsWidgetTitle',
+    defaultMessage: 'Settings',
+    description: 'Settings Title',
+  },
+  showAdvanceSettingsButtonText: {
+    id: 'authoring.problemeditor.settings.showAdvancedButton',
+    defaultMessage: 'Show advanced settings',
+    description: 'Button text to show advanced settings',
+  },
+  settingsDeleteIconAltText: {
+    id: 'authoring.problemeditor.settings.delete.icon.alt',
+    defaultMessage: 'Delete answer',
+    description: 'Alt text for delete icon',
+  },
+  advancedSettingsLinkText: {
+    id: 'authoring.problemeditor.settings.advancedSettingLink.text',
+    defaultMessage: 'Set a default value in advanced settings',
+    description: 'Advanced settings link text',
+  },
+  hintSettingTitle: {
+    id: 'authoring.problemeditor.settings.hint.title',
+    defaultMessage: 'Hints',
+    description: 'Hint settings card title',
+  },
+  hintInputLabel: {
+    id: 'authoring.problemeditor.settings.hint.inputLabel',
+    defaultMessage: 'Hint',
+    description: 'Hint text input label',
+  },
+  addHintButtonText: {
+    id: 'authoring.problemeditor.settings.hint.addHintButton',
+    defaultMessage: 'Add hint',
+    description: 'Add hint button text',
+  },
+  noHintSummary: {
+    id: 'authoring.problemeditor.settings.hint.noHintSummary',
+    defaultMessage: 'No Hints',
+    description: 'Summary text for no hints',
+  },
+  hintSummary: {
+    id: 'authoring.problemeditor.settings.hint.summary',
+    defaultMessage: '{hint} {count, plural, =0 {} other {(+# more)}}',
+    description: 'Summary text for hint settings',
+  },
+  matlabSettingTitle: {
+    id: 'authoring.problemeditor.settings.matlab.title',
+    defaultMessage: 'MATLAB API Key',
+    description: 'Matlab settings card title',
+  },
+  matlabSettingText1: {
+    id: 'authoring.problemeditor.settings.matlab.text.one',
+    defaultMessage: 'Enter the API key provided by MathWorks for accessing the MATLAB Hosted Service. This key is granted for exclusive use by this course for the specified duration.',
+    description: 'Matlab settings card text 1',
+  },
+  matlabSettingText2: {
+    id: 'authoring.problemeditor.settings.matlab.text.two',
+    defaultMessage: 'Please do not share the API key with other courses and notify MathWorks immediately if you believe the key is exposed or compromised. To obtain a key for your course, or to report an issue please contact',
+    description: 'Matlab settings card text 2',
+  },
+  matlabInputLabel: {
+    id: 'authoring.problemeditor.settings.matlab.inputLabel',
+    defaultMessage: 'API Key',
+    description: 'Matlab text input label',
+  },
+  matlabNoKeySummary: {
+    id: 'authoring.problemeditor.settings.matlab.noKeySummary',
+    defaultMessage: 'None',
+    description: 'Matlab no key summary',
+  },
+  resetSettingsTitle: {
+    id: 'authoring.problemeditor.settings.reset.title',
+    defaultMessage: 'Show reset option',
+    description: 'Reset settings card title',
+  },
+  resetSettingsTrue: {
+    id: 'authoring.problemeditor.settings.reset.true',
+    defaultMessage: 'True',
+    description: 'True option for reset',
+  },
+  resetSettingsFalse: {
+    id: 'authoring.problemeditor.settings.reset.false',
+    defaultMessage: 'False',
+    description: 'False option for reset',
+  },
+  resetSettingText: {
+    id: 'authoring.problemeditor.settings.reset.text',
+    defaultMessage: "Determines whether a 'Reset' button is shown so the user may reset their answer, generally for use in practice or formative assessments.",
+    description: 'Reset settings card text',
+  },
+  scoringSettingsTitle: {
+    id: 'authoring.problemeditor.settings.scoring.title',
+    defaultMessage: 'Scoring',
+    description: 'Scoring settings card title',
+  },
+  scoringAttemptsInputLabel: {
+    id: 'authoring.problemeditor.settings.scoring.attempts.inputLabel',
+    defaultMessage: 'Attempts',
+    description: 'Scoring attempts text input label',
+  },
+  scoringWeightInputLabel: {
+    id: 'authoring.problemeditor.settings.scoring.weight.inputLabel',
+    defaultMessage: 'Points',
+    description: 'Scoring weight input label',
+  },
+  scoringSummary: {
+    id: 'authoring.problemeditor.settings.scoring.summary',
+    defaultMessage: '{attempts, plural, =0 {Unlimited} other {#}} attempts - {weight, plural, =0 {Ungraded} other {# points}}',
+    description: 'Summary text for scoring settings',
+  },
+  showAnswerSettingsTitle: {
+    id: 'authoring.problemeditor.settings.showAnswer.title',
+    defaultMessage: 'Show answer',
+    description: 'Show Answer settings card title',
+  },
+  showAnswerAttemptsInputLabel: {
+    id: 'authoring.problemeditor.settings.showAnswer.attempts.inputLabel',
+    defaultMessage: 'Number of Attempts',
+    description: 'Show Answer attempts text input label',
+  },
+  showAnswerSettingText: {
+    id: 'authoring.problemeditor.settings.showAnswer.text',
+    defaultMessage: 'Define when learners can see the correct answer.',
+    description: 'Show Answer settings card text',
+  },
+  timerSettingsTitle: {
+    id: 'authoring.problemeditor.settings.timer.title',
+    defaultMessage: 'Time between attempts',
+    description: 'Timer settings card title',
+  },
+  timerSummary: {
+    id: 'authoring.problemeditor.settings.timer.summary',
+    defaultMessage: '{time} seconds',
+    description: 'Summary text for timer settings',
+  },
+  timerSettingText: {
+    id: 'authoring.problemeditor.settings.timer.text',
+    defaultMessage: 'Seconds a student must wait between submissions for a problem with multiple attempts.',
+    description: 'Timer settings card text',
+  },
+  timerInputLabel: {
+    id: 'authoring.problemeditor.settings.timer.inputLabel',
+    defaultMessage: 'Attempts',
+    description: 'Timer text input label',
+  },
+  typeSettingTitle: {
+    id: 'authoring.problemeditor.settings.type.title',
+    defaultMessage: 'Type',
+    description: 'Type settings card title',
+  },
 };
 
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintRow.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintRow.jsx
@@ -1,49 +1,49 @@
-import React from 'react'
+import React from 'react';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Col, Container, Form, Icon, IconButton, Row } from '@edx/paragon'
+import {
+  Col, Container, Form, Icon, IconButton, Row,
+} from '@edx/paragon';
 import { Delete } from '@edx/paragon/icons';
-import messages from '../messages';
 import PropTypes from 'prop-types';
+import messages from '../messages';
 
 export const HintRow = ({
-    value,
-    handleChange,
-    handleDelete,
-    //inject
-    intl,
-}) => {
-    return (
-        <Container fluid>
-            <Row>
-                <Col xs={10}>
-                    <Form.Group>
-                        <Form.Control
-                            value={value}
-                            onChange={handleChange}
-                            floatingLabel={intl.formatMessage(messages.hintInputLabel)}
-                        />
-                    </Form.Group>
-                </Col>
-    
-                <Col xs={2} >
-                    <IconButton
-                        src={Delete}
-                        iconAs={Icon}
-                        alt={intl.formatMessage(messages.settingsDeleteIconAltText)}
-                        onClick={handleDelete}
-                        variant="secondary"
-                    />
-                </Col>
-            </Row>
-        </Container>
-    )
-}
+  value,
+  handleChange,
+  handleDelete,
+  // inject
+  intl,
+}) => (
+  <Container fluid>
+    <Row>
+      <Col xs={10}>
+        <Form.Group>
+          <Form.Control
+            value={value}
+            onChange={handleChange}
+            floatingLabel={intl.formatMessage(messages.hintInputLabel)}
+          />
+        </Form.Group>
+      </Col>
+
+      <Col xs={2}>
+        <IconButton
+          src={Delete}
+          iconAs={Icon}
+          alt={intl.formatMessage(messages.settingsDeleteIconAltText)}
+          onClick={handleDelete}
+          variant="secondary"
+        />
+      </Col>
+    </Row>
+  </Container>
+);
 
 HintRow.propTypes = {
-    value: PropTypes.string.isRequired,
-    handleChange: PropTypes.func.isRequired,
-    handleDelete: PropTypes.func.isRequired,
-    intl: intlShape.isRequired,
+  value: PropTypes.string.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  handleDelete: PropTypes.func.isRequired,
+  intl: intlShape.isRequired,
 };
 
 export default injectIntl(HintRow);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintRow.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintRow.test.jsx
@@ -2,19 +2,18 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { formatMessage } from '../../../../../../../testUtils';
 import { HintRow } from './HintRow';
-import { HintsCard } from './HintsCard';
 
 describe('HintRow', () => {
-    const props = {
-        value: "hint_1",
-        handleChange: jest.fn(),
-        handleDelete: jest.fn(),
-        intl: { formatMessage },
-    };
+  const props = {
+    value: 'hint_1',
+    handleChange: jest.fn(),
+    handleDelete: jest.fn(),
+    intl: { formatMessage },
+  };
 
-    describe('snapshot', () => {
-        test('snapshot: renders hints row', () => {
-            expect(shallow(<HintRow {...props} />)).toMatchSnapshot();
-        });
+  describe('snapshot', () => {
+    test('snapshot: renders hints row', () => {
+      expect(shallow(<HintRow {...props} />)).toMatchSnapshot();
     });
+  });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintsCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintsCard.jsx
@@ -1,46 +1,52 @@
-import React from 'react'
+import React from 'react';
+import PropTypes from 'prop-types';
 import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
-import SettingsOption from '../SettingsOption';
-import { Button } from '@edx/paragon'
+import { Button } from '@edx/paragon';
 import { Add } from '@edx/paragon/icons';
+import SettingsOption from '../SettingsOption';
 import messages from '../messages';
 import { hintsCardHooks, hintsRowHooks } from '../hooks';
 import HintRow from './HintRow';
 
 export const HintsCard = ({
-    hints,
-    updateSettings,
-    //inject
-    intl,
+  hints,
+  updateSettings,
+  // inject
+  intl,
 }) => {
-    const { summary, handleAdd } = hintsCardHooks(hints, updateSettings);
-    return (
-        <SettingsOption
-            title={intl.formatMessage(messages.hintSettingTitle)}
-            summary={intl.formatMessage(summary.message, { ...summary.values })}
-        >
-            {hints.map((hint) => (
-                <HintRow
-                    key={hint.id}
-                    id={hint.id}
-                    value={hint.value}
-                    {...hintsRowHooks(hint.id, hints, updateSettings)}
-                />
-            ))}
-            <Button
-                className="my-3 ml-2"
-                iconBefore={Add}
-                variant="tertiary"
-                onClick={handleAdd}
-            >
-                <FormattedMessage {...messages.addHintButtonText} />
-            </Button>
-        </SettingsOption>
-    )
-}
+  const { summary, handleAdd } = hintsCardHooks(hints, updateSettings);
+  return (
+    <SettingsOption
+      title={intl.formatMessage(messages.hintSettingTitle)}
+      summary={intl.formatMessage(summary.message, { ...summary.values })}
+    >
+      {hints.map((hint) => (
+        <HintRow
+          key={hint.id}
+          id={hint.id}
+          value={hint.value}
+          {...hintsRowHooks(hint.id, hints, updateSettings)}
+        />
+      ))}
+      <Button
+        className="my-3 ml-2"
+        iconBefore={Add}
+        variant="tertiary"
+        onClick={handleAdd}
+      >
+        <FormattedMessage {...messages.addHintButtonText} />
+      </Button>
+    </SettingsOption>
+  );
+};
 
 HintsCard.propTypes = {
-    intl: intlShape.isRequired,
+  intl: intlShape.isRequired,
+  hints: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })).isRequired,
+  updateSettings: PropTypes.func.isRequired,
 };
 
 export default injectIntl(HintsCard);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintsCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintsCard.test.jsx
@@ -6,75 +6,74 @@ import { hintsCardHooks, hintsRowHooks } from '../hooks';
 import messages from '../messages';
 
 jest.mock('../hooks', () => ({
-    hintsCardHooks: jest.fn(),
-    hintsRowHooks: jest.fn(),
+  hintsCardHooks: jest.fn(),
+  hintsRowHooks: jest.fn(),
 }));
 
 describe('HintsCard', () => {
-    const hint1 = { id: 1, value: "hint1" }
-    const hint2 = { id: 2, value: "" }
-    const hints_0 = [];
-    const hints_1 = [hint1];
-    const hints_2 = [hint1, hint2];
-    const props = {
-        intl: { formatMessage },
-        hints: hints_0,
-        updateSettings: jest.fn().mockName('args.updateSettings'),
-        intl: { formatMessage },
-    };
+  const hint1 = { id: 1, value: 'hint1' };
+  const hint2 = { id: 2, value: '' };
+  const hints0 = [];
+  const hints1 = [hint1];
+  const hints2 = [hint1, hint2];
+  const props = {
+    intl: { formatMessage },
+    hints: hints0,
+    updateSettings: jest.fn().mockName('args.updateSettings'),
+  };
 
-    const hintsRowHooksProps = {
-        handleChange: jest.fn().mockName('hintsRowHooks.handleChange'),
-        handleDelete: jest.fn().mockName('hintsRowHooks.handleDelete'),
-    }
-    hintsRowHooks.mockReturnValue(hintsRowHooksProps);
+  const hintsRowHooksProps = {
+    handleChange: jest.fn().mockName('hintsRowHooks.handleChange'),
+    handleDelete: jest.fn().mockName('hintsRowHooks.handleDelete'),
+  };
+  hintsRowHooks.mockReturnValue(hintsRowHooksProps);
 
-    describe('behavior', () => {
-        it(' calls hintsCardHooks when initialized', () => {
-            const hintsCardHooksProps = {
-                summary: { message: messages.noHintSummary, values: {} },
-                handleAdd: jest.fn().mockName('hintsCardHooks.handleAdd'),
-            };
-            
-            hintsCardHooks.mockReturnValue(hintsCardHooksProps);
-            shallow(<HintsCard {...props} />);
-            expect(hintsCardHooks).toHaveBeenCalledWith( hints_0, props.updateSettings );
-        });
+  describe('behavior', () => {
+    it(' calls hintsCardHooks when initialized', () => {
+      const hintsCardHooksProps = {
+        summary: { message: messages.noHintSummary, values: {} },
+        handleAdd: jest.fn().mockName('hintsCardHooks.handleAdd'),
+      };
+
+      hintsCardHooks.mockReturnValue(hintsCardHooksProps);
+      shallow(<HintsCard {...props} />);
+      expect(hintsCardHooks).toHaveBeenCalledWith(hints0, props.updateSettings);
     });
+  });
 
-    describe('snapshot', () => {
-        test('snapshot: renders hints setting card no hints', () => {
-            const hintsCardHooksProps = {
-                summary: { message: messages.noHintSummary, values: {} },
-                handleAdd: jest.fn().mockName('hintsCardHooks.handleAdd'),
-            };
+  describe('snapshot', () => {
+    test('snapshot: renders hints setting card no hints', () => {
+      const hintsCardHooksProps = {
+        summary: { message: messages.noHintSummary, values: {} },
+        handleAdd: jest.fn().mockName('hintsCardHooks.handleAdd'),
+      };
 
-            hintsCardHooks.mockReturnValue(hintsCardHooksProps);
-            expect(shallow(<HintsCard {...props} />)).toMatchSnapshot();
-        });
-        test('snapshot: renders hints setting card one hint', () => {
-            const hintsCardHooksProps = {
-                summary: {
-                    message: messages.hintSummary,
-                    values: { hint: hint1.value, count: 1 }
-                },
-                handleAdd: jest.fn().mockName('hintsCardHooks.handleAdd'),
-            };
-
-            hintsCardHooks.mockReturnValue(hintsCardHooksProps);
-            expect(shallow(<HintsCard {...props} hints={hints_1} />)).toMatchSnapshot();
-        });
-        test('snapshot: renders hints setting card multiple hints', () => {
-            const hintsCardHooksProps = {
-                summary: {
-                    message: messages.hintSummary,
-                    values: { hint: hint2.value, count: 2 }
-                },
-                handleAdd: jest.fn().mockName('hintsCardHooks.handleAdd'),
-            };
-
-            hintsCardHooks.mockReturnValue(hintsCardHooksProps);
-            expect(shallow(<HintsCard {...props} hints={hints_2} />)).toMatchSnapshot();
-        });
+      hintsCardHooks.mockReturnValue(hintsCardHooksProps);
+      expect(shallow(<HintsCard {...props} />)).toMatchSnapshot();
     });
+    test('snapshot: renders hints setting card one hint', () => {
+      const hintsCardHooksProps = {
+        summary: {
+          message: messages.hintSummary,
+          values: { hint: hint1.value, count: 1 },
+        },
+        handleAdd: jest.fn().mockName('hintsCardHooks.handleAdd'),
+      };
+
+      hintsCardHooks.mockReturnValue(hintsCardHooksProps);
+      expect(shallow(<HintsCard {...props} hints={hints1} />)).toMatchSnapshot();
+    });
+    test('snapshot: renders hints setting card multiple hints', () => {
+      const hintsCardHooksProps = {
+        summary: {
+          message: messages.hintSummary,
+          values: { hint: hint2.value, count: 2 },
+        },
+        handleAdd: jest.fn().mockName('hintsCardHooks.handleAdd'),
+      };
+
+      hintsCardHooks.mockReturnValue(hintsCardHooksProps);
+      expect(shallow(<HintsCard {...props} hints={hints2} />)).toMatchSnapshot();
+    });
+  });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/MatlabCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/MatlabCard.jsx
@@ -1,51 +1,52 @@
 import React from 'react';
 import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
-import SettingsOption from '../SettingsOption';
-import { Form, MailtoLink } from '@edx/paragon'
+import { Form, MailtoLink } from '@edx/paragon';
 import PropTypes from 'prop-types';
+import SettingsOption from '../SettingsOption';
 import messages from '../messages';
 import { matlabCardHooks } from '../hooks';
 
 export const MatlabCard = ({
-    matLabApiKey,
-    updateSettings,
-    //inject
-    intl,
+  matLabApiKey,
+  updateSettings,
+  // inject
+  intl,
 }) => {
-    const { summary, handleChange } = matlabCardHooks(matLabApiKey, updateSettings);
+  const { summary, handleChange } = matlabCardHooks(matLabApiKey, updateSettings);
 
-    return (
-        <SettingsOption
-            title={intl.formatMessage(messages.matlabSettingTitle)}
-            summary={summary.intl ? intl.formatMessage(summary.message, { ...summary.values }) : summary.message}
-        >
-            <div className='halfSpacedMessage'>
-                <span>
-                    <FormattedMessage {...messages.matlabSettingText1} />
-                </span>
-            </div>
-            <div className='spacedMessage'>
-                <span>
-                    <FormattedMessage {...messages.matlabSettingText2} />&nbsp;
-                    <MailtoLink to="moocsupport@mathworks.com">
-                        moocsupport@mathworks.com
-                    </MailtoLink>
-                </span>
-            </div>
-            <Form.Group>
-                <Form.Control
-                    value={matLabApiKey}
-                    onChange={handleChange}
-                    floatingLabel={intl.formatMessage(messages.matlabInputLabel)}
-                />
-            </Form.Group>
-        </SettingsOption>
-    )
-}
+  return (
+    <SettingsOption
+      title={intl.formatMessage(messages.matlabSettingTitle)}
+      summary={summary.intl ? intl.formatMessage(summary.message, { ...summary.values }) : summary.message}
+    >
+      <div className="halfSpacedMessage">
+        <span>
+          <FormattedMessage {...messages.matlabSettingText1} />
+        </span>
+      </div>
+      <div className="spacedMessage">
+        <span>
+          <FormattedMessage {...messages.matlabSettingText2} />&nbsp;
+          <MailtoLink to="moocsupport@mathworks.com">
+            moocsupport@mathworks.com
+          </MailtoLink>
+        </span>
+      </div>
+      <Form.Group>
+        <Form.Control
+          value={matLabApiKey}
+          onChange={handleChange}
+          floatingLabel={intl.formatMessage(messages.matlabInputLabel)}
+        />
+      </Form.Group>
+    </SettingsOption>
+  );
+};
 
 MatlabCard.propTypes = {
-    matLabApiKey: PropTypes.string.isRequired,
-    intl: intlShape.isRequired,
+  matLabApiKey: PropTypes.string.isRequired,
+  updateSettings: PropTypes.func.isRequired,
+  intl: intlShape.isRequired,
 };
 
 export default injectIntl(MatlabCard);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/MatlabCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/MatlabCard.test.jsx
@@ -6,46 +6,45 @@ import { MatlabCard } from './MatlabCard';
 import messages from '../messages';
 
 jest.mock('../hooks', () => ({
-    matlabCardHooks: jest.fn(),
+  matlabCardHooks: jest.fn(),
 }));
 
-
 describe('MatlabCard', () => {
-    const matLabApiKey = "matlab_api_key"
-    const props = {
-        matLabApiKey: matLabApiKey,
-        updateSettings: jest.fn().mockName('args.updateSettings'),
-        intl: { formatMessage },
-    };
+  const matLabApiKey = 'matlab_api_key';
+  const props = {
+    matLabApiKey,
+    updateSettings: jest.fn().mockName('args.updateSettings'),
+    intl: { formatMessage },
+  };
 
-    describe('behavior', () => {
-        it(' calls resetCardHooks when initialized', () => {
-            const matlabCardHooksProps = {
-                summary: { message: matLabApiKey, values: {}, intl: false },
-                handleChange: jest.fn().mockName('matlabCardHooks.handleChange'),
-            };
-            matlabCardHooks.mockReturnValue(matlabCardHooksProps);
-            shallow(<MatlabCard {...props} />);
-            expect(matlabCardHooks).toHaveBeenCalledWith(matLabApiKey, props.updateSettings);
-        });
+  describe('behavior', () => {
+    it(' calls resetCardHooks when initialized', () => {
+      const matlabCardHooksProps = {
+        summary: { message: matLabApiKey, values: {}, intl: false },
+        handleChange: jest.fn().mockName('matlabCardHooks.handleChange'),
+      };
+      matlabCardHooks.mockReturnValue(matlabCardHooksProps);
+      shallow(<MatlabCard {...props} />);
+      expect(matlabCardHooks).toHaveBeenCalledWith(matLabApiKey, props.updateSettings);
     });
+  });
 
-    describe('snapshot', () => {
-        test('snapshot: renders matlab setting card', () => {
-            const matlabCardHooksProps = {
-                summary: { message: matLabApiKey, values: {}, intl: false },
-                handleChange: jest.fn().mockName('matlabCardHooks.handleChange'),
-            };
-            matlabCardHooks.mockReturnValue(matlabCardHooksProps);
-            expect(shallow(<MatlabCard {...props} />)).toMatchSnapshot();
-        });
-        test('snapshot: renders matlab setting card no key', () => {
-            const matlabCardHooksProps = {
-                summary: { message: messages.matlabNoKeySummary, values: {}, intl: true },
-                handleChange: jest.fn().mockName('matlabCardHooks.handleChange'),
-            };
-            matlabCardHooks.mockReturnValue(matlabCardHooksProps);
-            expect(shallow(<MatlabCard {...props} matLabApiKey="" />)).toMatchSnapshot();
-        });
+  describe('snapshot', () => {
+    test('snapshot: renders matlab setting card', () => {
+      const matlabCardHooksProps = {
+        summary: { message: matLabApiKey, values: {}, intl: false },
+        handleChange: jest.fn().mockName('matlabCardHooks.handleChange'),
+      };
+      matlabCardHooks.mockReturnValue(matlabCardHooksProps);
+      expect(shallow(<MatlabCard {...props} />)).toMatchSnapshot();
     });
+    test('snapshot: renders matlab setting card no key', () => {
+      const matlabCardHooksProps = {
+        summary: { message: messages.matlabNoKeySummary, values: {}, intl: true },
+        handleChange: jest.fn().mockName('matlabCardHooks.handleChange'),
+      };
+      matlabCardHooks.mockReturnValue(matlabCardHooksProps);
+      expect(shallow(<MatlabCard {...props} matLabApiKey="" />)).toMatchSnapshot();
+    });
+  });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.jsx
@@ -1,49 +1,51 @@
 import React from 'react';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import SettingsOption from '../SettingsOption';
 import { Button, ButtonGroup, Hyperlink } from '@edx/paragon';
 import PropTypes from 'prop-types';
+import SettingsOption from '../SettingsOption';
 import messages from '../messages';
 import { resetCardHooks } from '../hooks';
 
 export const ResetCard = ({
-    showResetButton,
-    updateSettings,
-    //inject
-    intl,
+  showResetButton,
+  updateSettings,
+  // inject
+  intl,
 }) => {
-    const { setResetTrue, setResetFalse } = resetCardHooks(updateSettings);
-    return (
-        <SettingsOption
-            title={intl.formatMessage(messages.resetSettingsTitle)}
-            summary={showResetButton ? intl.formatMessage(messages.resetSettingsTrue) : intl.formatMessage(messages.resetSettingsFalse)}
-        >
-            <div className='halfSpacedMessage'>
-                <span>
-                    <FormattedMessage {...messages.resetSettingText} />
-                </span>
-            </div>
-            <div className='spacedMessage'>
-                <Hyperlink destination="#" target="_blank">
-                    <FormattedMessage {...messages.advancedSettingsLinkText} />
-                </Hyperlink>
-            </div>
-            <ButtonGroup size="lg" className="mb-2">
-                <Button variant={showResetButton ? "outline-primary" : "primary"} onClick={setResetFalse} >
-                    <FormattedMessage {...messages.resetSettingsFalse} />
-                </Button>
-                <Button variant={showResetButton ? "primary" : "outline-primary"} onClick={setResetTrue} >
-                    <FormattedMessage {...messages.resetSettingsTrue} />
-                </Button>
-            </ButtonGroup>
-        </SettingsOption>
-    )
-}
+  const { setResetTrue, setResetFalse } = resetCardHooks(updateSettings);
+  return (
+    <SettingsOption
+      title={intl.formatMessage(messages.resetSettingsTitle)}
+      summary={showResetButton
+        ? intl.formatMessage(messages.resetSettingsTrue) : intl.formatMessage(messages.resetSettingsFalse)}
+    >
+      <div className="halfSpacedMessage">
+        <span>
+          <FormattedMessage {...messages.resetSettingText} />
+        </span>
+      </div>
+      <div className="spacedMessage">
+        <Hyperlink destination="#" target="_blank">
+          <FormattedMessage {...messages.advancedSettingsLinkText} />
+        </Hyperlink>
+      </div>
+      <ButtonGroup size="lg" className="mb-2">
+        <Button variant={showResetButton ? 'outline-primary' : 'primary'} onClick={setResetFalse}>
+          <FormattedMessage {...messages.resetSettingsFalse} />
+        </Button>
+        <Button variant={showResetButton ? 'primary' : 'outline-primary'} onClick={setResetTrue}>
+          <FormattedMessage {...messages.resetSettingsTrue} />
+        </Button>
+      </ButtonGroup>
+    </SettingsOption>
+  );
+};
 
 ResetCard.propTypes = {
-    showResetButton: PropTypes.bool.isRequired,
-    // injected
-    intl: intlShape.isRequired,
+  showResetButton: PropTypes.bool.isRequired,
+  updateSettings: PropTypes.func.isRequired,
+  // injected
+  intl: intlShape.isRequired,
 };
 
 export default injectIntl(ResetCard);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.test.jsx
@@ -8,9 +8,7 @@ jest.mock('../hooks', () => ({
   resetCardHooks: jest.fn(),
 }));
 
-
 describe('ResetCard', () => {
-
   const props = {
     showResetButton: false,
     updateSettings: jest.fn().mockName('args.updateSettings'),
@@ -26,17 +24,17 @@ describe('ResetCard', () => {
 
   describe('behavior', () => {
     it(' calls resetCardHooks when initialized', () => {
-        shallow(<ResetCard {...props} />);
-        expect(resetCardHooks).toHaveBeenCalledWith( props.updateSettings );
+      shallow(<ResetCard {...props} />);
+      expect(resetCardHooks).toHaveBeenCalledWith(props.updateSettings);
     });
-});
+  });
 
   describe('snapshot', () => {
     test('snapshot: renders reset true setting card', () => {
       expect(shallow(<ResetCard {...props} />)).toMatchSnapshot();
     });
     test('snapshot: renders reset true setting card', () => {
-      expect(shallow(<ResetCard {...props} showResetButton={true} />)).toMatchSnapshot();
+      expect(shallow(<ResetCard {...props} showResetButton />)).toMatchSnapshot();
     });
   });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
@@ -1,45 +1,50 @@
-import React from 'react'
+import React from 'react';
+import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import SettingsOption from '../SettingsOption';
 import { Form } from '@edx/paragon';
+import SettingsOption from '../SettingsOption';
 import messages from '../messages';
 import { scoringCardHooks } from '../hooks';
 
 export const ScoringCard = ({
-    scoring,
-    updateSettings,
-    //inject
-    intl,
+  scoring,
+  updateSettings,
+  // inject
+  intl,
 }) => {
-    const { handleMaxAttemptChange, handleWeightChange } = scoringCardHooks(scoring, updateSettings);
+  const { handleMaxAttemptChange, handleWeightChange } = scoringCardHooks(scoring, updateSettings);
 
-    return (
-        <SettingsOption
-            title={intl.formatMessage(messages.scoringSettingsTitle)}
-            summary={intl.formatMessage(messages.scoringSummary, { attempts: scoring.attempts.number, weight: scoring.weight })}
-        >
-            <Form.Group>
-                <Form.Control
-                    type="number"
-                    value={scoring.attempts.number}
-                    onChange={handleMaxAttemptChange}
-                    floatingLabel={intl.formatMessage(messages.scoringAttemptsInputLabel)}
-                />
-            </Form.Group>
-            <Form.Group>
-                <Form.Control
-                    type="number"
-                    value={scoring.weight}
-                    onChange={handleWeightChange}
-                    floatingLabel={intl.formatMessage(messages.scoringWeightInputLabel)}
-                />
-            </Form.Group>
-        </SettingsOption>
-    )
-}
+  return (
+    <SettingsOption
+      title={intl.formatMessage(messages.scoringSettingsTitle)}
+      summary={intl.formatMessage(messages.scoringSummary,
+        { attempts: scoring.attempts.number, weight: scoring.weight })}
+    >
+      <Form.Group>
+        <Form.Control
+          type="number"
+          value={scoring.attempts.number}
+          onChange={handleMaxAttemptChange}
+          floatingLabel={intl.formatMessage(messages.scoringAttemptsInputLabel)}
+        />
+      </Form.Group>
+      <Form.Group>
+        <Form.Control
+          type="number"
+          value={scoring.weight}
+          onChange={handleWeightChange}
+          floatingLabel={intl.formatMessage(messages.scoringWeightInputLabel)}
+        />
+      </Form.Group>
+    </SettingsOption>
+  );
+};
 
 ScoringCard.propTypes = {
-    intl: intlShape.isRequired,
+  intl: intlShape.isRequired,
+  // eslint-disable-next-line
+  scoring: PropTypes.any.isRequired,
+  updateSettings: PropTypes.func.isRequired,
 };
 
 export default injectIntl(ScoringCard);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
@@ -5,58 +5,63 @@ import { scoringCardHooks } from '../hooks';
 import { ScoringCard } from './ScoringCard';
 
 jest.mock('../hooks', () => ({
-    scoringCardHooks: jest.fn(),
+  scoringCardHooks: jest.fn(),
 }));
 
-
 describe('ScoringCard', () => {
-    const scoring = {
-        weight: 1.5,
-        attempts: {
-            unlimited: false,
-            number: 5,
-        },
-        updateSettings: jest.fn().mockName('args.updateSettings'),
-        intl: { formatMessage },
-    };
-    
-    const props = {
-        scoring: scoring,
-        intl: { formatMessage },
-    };
+  const scoring = {
+    weight: 1.5,
+    attempts: {
+      unlimited: false,
+      number: 5,
+    },
+    updateSettings: jest.fn().mockName('args.updateSettings'),
+    intl: { formatMessage },
+  };
 
-    const scoringCardHooksProps = {
-        handleMaxAttemptChange: jest.fn().mockName('scoringCardHooks.handleMaxAttemptChange'),
-        handleWeightChange: jest.fn().mockName('scoringCardHooks.handleWeightChange'),
-    };
+  const props = {
+    scoring,
+    intl: { formatMessage },
+  };
 
-    scoringCardHooks.mockReturnValue(scoringCardHooksProps);
+  const scoringCardHooksProps = {
+    handleMaxAttemptChange: jest.fn().mockName('scoringCardHooks.handleMaxAttemptChange'),
+    handleWeightChange: jest.fn().mockName('scoringCardHooks.handleWeightChange'),
+  };
 
-    describe('behavior', () => {
-        it(' calls scoringCardHooks when initialized', () => {
-            shallow(<ScoringCard {...props} />);
-            expect(scoringCardHooks).toHaveBeenCalledWith(scoring, props.updateSettings);
-        });
+  scoringCardHooks.mockReturnValue(scoringCardHooksProps);
+
+  describe('behavior', () => {
+    it(' calls scoringCardHooks when initialized', () => {
+      shallow(<ScoringCard {...props} />);
+      expect(scoringCardHooks).toHaveBeenCalledWith(scoring, props.updateSettings);
     });
+  });
 
-      describe('snapshot', () => {
-        test('snapshot: scoring setting card', () => {
-          expect(shallow(<ScoringCard {...props} />)).toMatchSnapshot();
-        });
-        test('snapshot: scoring setting card zero zero weight', () => {
-            expect(shallow(<ScoringCard {...props} scoring={{
-                ...scoring,
-                weight:0,
-            }} />)).toMatchSnapshot();
-          });
-          test('snapshot: scoring setting card max attempts', () => {
-            expect(shallow(<ScoringCard {...props} scoring={{
-                ...scoring,
-                attempts: {
-                    unlimited: true,
-                    number: 0,
-                },
-            }} />)).toMatchSnapshot();
-          });
-      });
+  describe('snapshot', () => {
+    test('snapshot: scoring setting card', () => {
+      expect(shallow(<ScoringCard {...props} />)).toMatchSnapshot();
+    });
+    test('snapshot: scoring setting card zero zero weight', () => {
+      expect(shallow(<ScoringCard
+        {...props}
+        scoring={{
+          ...scoring,
+          weight: 0,
+        }}
+      />)).toMatchSnapshot();
+    });
+    test('snapshot: scoring setting card max attempts', () => {
+      expect(shallow(<ScoringCard
+        {...props}
+        scoring={{
+          ...scoring,
+          attempts: {
+            unlimited: true,
+            number: 0,
+          },
+        }}
+      />)).toMatchSnapshot();
+    });
+  });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
@@ -35,9 +35,9 @@ export const ShowAnswerCard = ({
           value={showAnswer.on}
           onChange={handleShowAnswerChange}
         >
-          {Object.values(ShowAnswerTypesKeys).map((answerType, i) => (
+          {Object.values(ShowAnswerTypesKeys).map((answerType) => (
             <option
-              key={Symbol(i)}
+              key={answerType}
               value={answerType}
             >
               {intl.formatMessage(ShowAnswerTypes[answerType])}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
@@ -1,63 +1,67 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
-import SettingsOption from '../SettingsOption';
 import { Form, Hyperlink } from '@edx/paragon';
+import SettingsOption from '../SettingsOption';
 import { ShowAnswerTypes, ShowAnswerTypesKeys } from '../../../../../../data/constants/problem';
 import messages from '../messages';
 import { showAnswerCardHooks } from '../hooks';
 
 export const ShowAnswerCard = ({
-    showAnswer,
-    updateSettings,
-    //inject
-    intl,
+  showAnswer,
+  updateSettings,
+  // inject
+  intl,
 }) => {
-    const { handleShowAnswerChange, handleAttemptsChange } = showAnswerCardHooks(showAnswer, updateSettings);
-    return (
-        <SettingsOption
-            title={intl.formatMessage(messages.showAnswerSettingsTitle)}
-            summary={intl.formatMessage(ShowAnswerTypes[showAnswer.on])}
+  const { handleShowAnswerChange, handleAttemptsChange } = showAnswerCardHooks(showAnswer, updateSettings);
+  return (
+    <SettingsOption
+      title={intl.formatMessage(messages.showAnswerSettingsTitle)}
+      summary={intl.formatMessage(ShowAnswerTypes[showAnswer.on])}
+    >
+      <div className="halfSpacedMessage">
+        <span>
+          <FormattedMessage {...messages.showAnswerSettingText} />
+        </span>
+      </div>
+      <div className="spacedMessage">
+        <Hyperlink destination="#" target="_blank">
+          <FormattedMessage {...messages.advancedSettingsLinkText} />
+        </Hyperlink>
+      </div>
+      <Form.Group>
+        <Form.Control
+          as="select"
+          value={showAnswer.on}
+          onChange={handleShowAnswerChange}
         >
-            <div className='halfSpacedMessage'>
-                <span>
-                    <FormattedMessage {...messages.showAnswerSettingText} />
-                </span>
-            </div>
-            <div className='spacedMessage'>
-                <Hyperlink destination="#" target="_blank">
-                    <FormattedMessage {...messages.advancedSettingsLinkText} />
-                </Hyperlink>
-            </div>
-            <Form.Group>
-                <Form.Control
-                    as="select"
-                    value={showAnswer.on}
-                    onChange={handleShowAnswerChange}
-                >
-                    {Object.values(ShowAnswerTypesKeys).map((answerType, i) => (
-                        <option
-                            key={i}
-                            value={answerType}
-                        >
-                            {intl.formatMessage(ShowAnswerTypes[answerType])}
-                        </option>
-                    ))}
-                </Form.Control>
-            </Form.Group>
-            <Form.Group>
-                <Form.Control
-                    type="number"
-                    value={showAnswer.afterAttempts}
-                    onChange={handleAttemptsChange}
-                    floatingLabel={intl.formatMessage(messages.showAnswerAttemptsInputLabel)}
-                />
-            </Form.Group>
-        </SettingsOption>
-    )
-}
+          {Object.values(ShowAnswerTypesKeys).map((answerType, i) => (
+            <option
+              key={Symbol(i)}
+              value={answerType}
+            >
+              {intl.formatMessage(ShowAnswerTypes[answerType])}
+            </option>
+          ))}
+        </Form.Control>
+      </Form.Group>
+      <Form.Group>
+        <Form.Control
+          type="number"
+          value={showAnswer.afterAttempts}
+          onChange={handleAttemptsChange}
+          floatingLabel={intl.formatMessage(messages.showAnswerAttemptsInputLabel)}
+        />
+      </Form.Group>
+    </SettingsOption>
+  );
+};
 
 ShowAnswerCard.propTypes = {
-    intl: intlShape.isRequired,
+  intl: intlShape.isRequired,
+  // eslint-disable-next-line
+  showAnswer: PropTypes.any.isRequired,
+  updateSettings: PropTypes.func.isRequired,
 };
 
 export default injectIntl(ShowAnswerCard);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
@@ -13,7 +13,11 @@ export const ShowAnswerCard = ({
   // inject
   intl,
 }) => {
-  const { handleShowAnswerChange, handleAttemptsChange } = showAnswerCardHooks(showAnswer, updateSettings);
+  const {
+    handleShowAnswerChange,
+    handleAttemptsChange,
+    showAttempts,
+  } = showAnswerCardHooks(showAnswer, updateSettings);
   return (
     <SettingsOption
       title={intl.formatMessage(messages.showAnswerSettingsTitle)}
@@ -45,14 +49,17 @@ export const ShowAnswerCard = ({
           ))}
         </Form.Control>
       </Form.Group>
-      <Form.Group>
-        <Form.Control
-          type="number"
-          value={showAnswer.afterAttempts}
-          onChange={handleAttemptsChange}
-          floatingLabel={intl.formatMessage(messages.showAnswerAttemptsInputLabel)}
-        />
-      </Form.Group>
+      { showAttempts
+        && (
+        <Form.Group>
+          <Form.Control
+            type="number"
+            value={showAnswer.afterAttempts}
+            onChange={handleAttemptsChange}
+            floatingLabel={intl.formatMessage(messages.showAnswerAttemptsInputLabel)}
+          />
+        </Form.Group>
+        )}
     </SettingsOption>
   );
 };

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.test.jsx
@@ -5,39 +5,38 @@ import { ShowAnswerCard } from './ShowAnswerCard';
 import { showAnswerCardHooks } from '../hooks';
 
 jest.mock('../hooks', () => ({
-    showAnswerCardHooks: jest.fn(),
+  showAnswerCardHooks: jest.fn(),
 }));
 
-
 describe('ShowAnswerCard', () => {
-    const showAnswer = {
-        on: "after_attempts",
-        afterAttempts: 5,
-        updateSettings: jest.fn().mockName('args.updateSettings'),
-        intl: { formatMessage },
-    }
-    const props = {
-        showAnswer: showAnswer,
-        intl: { formatMessage },
-    };
+  const showAnswer = {
+    on: 'after_attempts',
+    afterAttempts: 5,
+    updateSettings: jest.fn().mockName('args.updateSettings'),
+    intl: { formatMessage },
+  };
+  const props = {
+    showAnswer,
+    intl: { formatMessage },
+  };
 
-    const showAnswerCardHooksProps = {
-        handleShowAnswerChange: jest.fn().mockName('showAnswerCardHooks.handleShowAnswerChange'),
-        handleAttemptsChange: jest.fn().mockName('showAnswerCardHooks.handleAttemptsChange'),
-    };
+  const showAnswerCardHooksProps = {
+    handleShowAnswerChange: jest.fn().mockName('showAnswerCardHooks.handleShowAnswerChange'),
+    handleAttemptsChange: jest.fn().mockName('showAnswerCardHooks.handleAttemptsChange'),
+  };
 
-    showAnswerCardHooks.mockReturnValue(showAnswerCardHooksProps);
+  showAnswerCardHooks.mockReturnValue(showAnswerCardHooksProps);
 
-    describe('behavior', () => {
-        it(' calls showAnswerCardHooks when initialized', () => {
-            shallow(<ShowAnswerCard {...props} />);
-            expect(showAnswerCardHooks).toHaveBeenCalledWith(showAnswer, props.updateSettings);
-        });
+  describe('behavior', () => {
+    it(' calls showAnswerCardHooks when initialized', () => {
+      shallow(<ShowAnswerCard {...props} />);
+      expect(showAnswerCardHooks).toHaveBeenCalledWith(showAnswer, props.updateSettings);
     });
+  });
 
-    describe('snapshot', () => {
-        test('snapshot: show answer setting card', () => {
-            expect(shallow(<ShowAnswerCard {...props} />)).toMatchSnapshot();
-        });
+  describe('snapshot', () => {
+    test('snapshot: show answer setting card', () => {
+      expect(shallow(<ShowAnswerCard {...props} />)).toMatchSnapshot();
     });
+  });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TimerCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TimerCard.jsx
@@ -1,44 +1,45 @@
 import React from 'react';
 import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
-import SettingsOption from '../SettingsOption';
 import { Form } from '@edx/paragon';
 import PropTypes from 'prop-types';
+import SettingsOption from '../SettingsOption';
 import messages from '../messages';
 import { timerCardHooks } from '../hooks';
 
 export const TimerCard = ({
-    timeBetween,
-    updateSettings,
-    //inject
-    intl
+  timeBetween,
+  updateSettings,
+  // inject
+  intl,
 }) => {
-    const { handleChange } = timerCardHooks(updateSettings);
+  const { handleChange } = timerCardHooks(updateSettings);
 
-    return (
-        <SettingsOption
-            title={intl.formatMessage(messages.timerSettingsTitle)}
-            summary={intl.formatMessage(messages.timerSummary, { time: timeBetween })}
-        >
-            <div className='spacedMessage'>
-                <span>
-                    <FormattedMessage {...messages.timerSettingText} />
-                </span>
-            </div>
-            <Form.Group>
-                <Form.Control
-                    type="number"
-                    value={timeBetween}
-                    onChange={handleChange}
-                    floatingLabel={intl.formatMessage(messages.timerInputLabel)}
-                />
-            </Form.Group>
-        </SettingsOption>
-    )
-}
+  return (
+    <SettingsOption
+      title={intl.formatMessage(messages.timerSettingsTitle)}
+      summary={intl.formatMessage(messages.timerSummary, { time: timeBetween })}
+    >
+      <div className="spacedMessage">
+        <span>
+          <FormattedMessage {...messages.timerSettingText} />
+        </span>
+      </div>
+      <Form.Group>
+        <Form.Control
+          type="number"
+          value={timeBetween}
+          onChange={handleChange}
+          floatingLabel={intl.formatMessage(messages.timerInputLabel)}
+        />
+      </Form.Group>
+    </SettingsOption>
+  );
+};
 
 TimerCard.propTypes = {
-    timeBetween: PropTypes.number.isRequired,
-    intl: intlShape.isRequired,
+  timeBetween: PropTypes.number.isRequired,
+  updateSettings: PropTypes.func.isRequired,
+  intl: intlShape.isRequired,
 };
 
 export default injectIntl(TimerCard);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TimerCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TimerCard.test.jsx
@@ -8,9 +8,7 @@ jest.mock('../hooks', () => ({
   timerCardHooks: jest.fn(),
 }));
 
-
 describe('TimerCard', () => {
-
   const props = {
     timeBetween: 5,
     updateSettings: jest.fn().mockName('args.updateSettings'),
@@ -25,10 +23,10 @@ describe('TimerCard', () => {
 
   describe('behavior', () => {
     it(' calls timerCardHooks when initialized', () => {
-        shallow(<TimerCard {...props} />);
-        expect(timerCardHooks).toHaveBeenCalledWith( props.updateSettings );
+      shallow(<TimerCard {...props} />);
+      expect(timerCardHooks).toHaveBeenCalledWith(props.updateSettings);
     });
-});
+  });
 
   describe('snapshot', () => {
     test('snapshot: renders reset true setting card', () => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TypeCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TypeCard.jsx
@@ -1,41 +1,42 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import SettingsOption from '../SettingsOption';
 import { ProblemTypeKeys, ProblemTypes } from '../../../../../../data/constants/problem';
 import messages from '../messages';
 import TypeRow from './TypeRow';
 
-
 export const TypeCard = ({
-    problemType,
-    updateField,
-    //inject
-    intl,
+  problemType,
+  updateField,
+  // inject
+  intl,
 }) => {
+  const problemTypeKeysArray = Object.values(ProblemTypeKeys);
 
-    const problemTypeKeysArray = Object.values(ProblemTypeKeys);
-
-    return (
-        <SettingsOption
-            title={intl.formatMessage(messages.typeSettingTitle)}
-            summary={ProblemTypes[problemType].title}
-        >
-            {problemTypeKeysArray.map((typeKey, i) => (
-                <TypeRow
-                    key={i}
-                    typeKey={typeKey}
-                    label={ProblemTypes[typeKey].title}
-                    selected={typeKey !== problemType}
-                    lastRow={(i + 1) == problemTypeKeysArray.length}
-                    updateField={updateField}
-                />
-            ))}
-        </SettingsOption>
-    )
-}
+  return (
+    <SettingsOption
+      title={intl.formatMessage(messages.typeSettingTitle)}
+      summary={ProblemTypes[problemType].title}
+    >
+      {problemTypeKeysArray.map((typeKey, i) => (
+        <TypeRow
+          key={typeKey}
+          typeKey={typeKey}
+          label={ProblemTypes[typeKey].title}
+          selected={typeKey !== problemType}
+          lastRow={(i + 1) === problemTypeKeysArray.length}
+          updateField={updateField}
+        />
+      ))}
+    </SettingsOption>
+  );
+};
 
 TypeCard.propTypes = {
-    intl: intlShape.isRequired,
+  intl: intlShape.isRequired,
+  problemType: PropTypes.string.isRequired,
+  updateField: PropTypes.func.isRequired,
 };
 
 export default injectIntl(TypeCard);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TypeCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TypeCard.test.jsx
@@ -5,13 +5,11 @@ import { TypeCard } from './TypeCard';
 import { ProblemTypeKeys } from '../../../../../../data/constants/problem';
 
 describe('TypeCard', () => {
-
   const props = {
     problemType: ProblemTypeKeys.TEXTINPUT,
     updateField: jest.fn().mockName('args.updateField'),
     intl: { formatMessage },
   };
-
 
   describe('snapshot', () => {
     test('snapshot: renders type setting card', () => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TypeRow.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TypeRow.jsx
@@ -4,33 +4,32 @@ import PropTypes from 'prop-types';
 import { Check } from '@edx/paragon/icons';
 import { typeRowHooks } from '../hooks';
 
-
 export const TypeRow = ({
-    typeKey,
-    label,
-    selected,
-    lastRow,
-    updateField,
+  typeKey,
+  label,
+  selected,
+  lastRow,
+  updateField,
 }) => {
+  const { onClick } = typeRowHooks(typeKey, updateField);
 
-    const {onClick} = typeRowHooks(typeKey, updateField);
-
-    return (
-        <>
-            <Container size="xl" onClick={onClick} role='button' className="d-flex" fluid>
-                <span className="flex-grow-1">{label}</span>
-                <span hidden={selected}><Icon src={Check} className="text-success" /></span>
-            </Container>
-            <hr className={lastRow ? 'd-none' : 'd-block'} />
-        </>
-    );
-}
-
+  return (
+    <>
+      <Container size="xl" onClick={onClick} role="button" className="d-flex" fluid>
+        <span className="flex-grow-1">{label}</span>
+        <span hidden={selected}><Icon src={Check} className="text-success" /></span>
+      </Container>
+      <hr className={lastRow ? 'd-none' : 'd-block'} />
+    </>
+  );
+};
 
 TypeRow.propTypes = {
-    label: PropTypes.string.isRequired,
-    selected: PropTypes.bool.isRequired,
-    lastRow: PropTypes.bool.isRequired,
+  typeKey: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  selected: PropTypes.bool.isRequired,
+  lastRow: PropTypes.bool.isRequired,
+  updateField: PropTypes.func.isRequired,
 };
 
 export default TypeRow;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TypeRow.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/TypeRow.test.jsx
@@ -4,42 +4,41 @@ import { TypeRow } from './TypeRow';
 import { typeRowHooks } from '../hooks';
 
 jest.mock('../hooks', () => ({
-    typeRowHooks: jest.fn(),
+  typeRowHooks: jest.fn(),
 }));
 
-
 describe('TypeRow', () => {
-    const typeKey = "TEXTINPUT"
-    const props = {
-        typeKey: typeKey,
-        label: "Text Input Problem",
-        selected: true,
-        lastRow: false,
-        updateField: jest.fn().mockName('args.updateField'),
-    };
+  const typeKey = 'TEXTINPUT';
+  const props = {
+    typeKey,
+    label: 'Text Input Problem',
+    selected: true,
+    lastRow: false,
+    updateField: jest.fn().mockName('args.updateField'),
+  };
 
-    const typeRowHooksProps = {
-        onClick: jest.fn().mockName('typeRowHooks.onClick'),
-    };
+  const typeRowHooksProps = {
+    onClick: jest.fn().mockName('typeRowHooks.onClick'),
+  };
 
-    typeRowHooks.mockReturnValue(typeRowHooksProps);
+  typeRowHooks.mockReturnValue(typeRowHooksProps);
 
-    describe('behavior', () => {
-        it(' calls typeRowHooks when initialized', () => {
-            shallow(<TypeRow {...props} />);
-            expect(typeRowHooks).toHaveBeenCalledWith(typeKey, props.updateField);
-        });
+  describe('behavior', () => {
+    it(' calls typeRowHooks when initialized', () => {
+      shallow(<TypeRow {...props} />);
+      expect(typeRowHooks).toHaveBeenCalledWith(typeKey, props.updateField);
     });
+  });
 
-    describe('snapshot', () => {
-        test('snapshot: renders type row setting card', () => {
-            expect(shallow(<TypeRow {...props} />)).toMatchSnapshot();
-        });
-        test('snapshot: renders type row setting card not selected', () => {
-            expect(shallow(<TypeRow {...props} selected={false} />)).toMatchSnapshot();
-        });
-        test('snapshot: renders type row setting card last row', () => {
-            expect(shallow(<TypeRow {...props} lastRow={true} />)).toMatchSnapshot();
-        });
+  describe('snapshot', () => {
+    test('snapshot: renders type row setting card', () => {
+      expect(shallow(<TypeRow {...props} />)).toMatchSnapshot();
     });
+    test('snapshot: renders type row setting card not selected', () => {
+      expect(shallow(<TypeRow {...props} selected={false} />)).toMatchSnapshot();
+    });
+    test('snapshot: renders type row setting card last row', () => {
+      expect(shallow(<TypeRow {...props} lastRow />)).toMatchSnapshot();
+    });
+  });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ShowAnswerCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ShowAnswerCard.test.jsx.snap
@@ -37,73 +37,73 @@ exports[`ShowAnswerCard snapshot snapshot: show answer setting card 1`] = `
       value="after_attempts"
     >
       <option
-        key="0"
+        key="always"
         value="always"
       >
         Always
       </option>
       <option
-        key="1"
+        key="answered"
         value="answered"
       >
         Answered
       </option>
       <option
-        key="2"
+        key="attempted"
         value="attempted"
       >
         Attempted or Past Due
       </option>
       <option
-        key="3"
+        key="closed"
         value="closed"
       >
         Closed
       </option>
       <option
-        key="4"
+        key="finished"
         value="finished"
       >
         Finished
       </option>
       <option
-        key="5"
+        key="correct_or_past_due"
         value="correct_or_past_due"
       >
         Correct or Past Due
       </option>
       <option
-        key="6"
+        key="past_due"
         value="past_due"
       >
         Past Due
       </option>
       <option
-        key="7"
+        key="never"
         value="never"
       >
         Never
       </option>
       <option
-        key="8"
+        key="after_attempts"
         value="after_attempts"
       >
         After Some Number of Attempts
       </option>
       <option
-        key="9"
+        key="after_all_attempts"
         value="after_all_attempts"
       >
         After All Attempts
       </option>
       <option
-        key="10"
+        key="after_all_attempts_or_correct"
         value="after_all_attempts_or_correct"
       >
         After All Attempts or Correct
       </option>
       <option
-        key="11"
+        key="attempted_no_past_due"
         value="attempted_no_past_due"
       >
         Attempted

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ShowAnswerCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ShowAnswerCard.test.jsx.snap
@@ -110,13 +110,5 @@ exports[`ShowAnswerCard snapshot snapshot: show answer setting card 1`] = `
       </option>
     </Form.Control>
   </Form.Group>
-  <Form.Group>
-    <Form.Control
-      floatingLabel="Number of Attempts"
-      onChange={[MockFunction showAnswerCardHooks.handleAttemptsChange]}
-      type="number"
-      value={5}
-    />
-  </Form.Group>
 </SettingsOption>
 `;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/TypeCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/TypeCard.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`TypeCard snapshot snapshot: renders type setting card 1`] = `
   title="Type"
 >
   <TypeRow
-    key="0"
+    key="stringresponse"
     label="Text Input Problem"
     lastRow={false}
     selected={false}
@@ -14,7 +14,7 @@ exports[`TypeCard snapshot snapshot: renders type setting card 1`] = `
     updateField={[MockFunction args.updateField]}
   />
   <TypeRow
-    key="1"
+    key="numericalresponse"
     label="Numeric Response Problem"
     lastRow={false}
     selected={true}
@@ -22,7 +22,7 @@ exports[`TypeCard snapshot snapshot: renders type setting card 1`] = `
     updateField={[MockFunction args.updateField]}
   />
   <TypeRow
-    key="2"
+    key="optionresponse"
     label="Dropdown Problem"
     lastRow={false}
     selected={true}
@@ -30,7 +30,7 @@ exports[`TypeCard snapshot snapshot: renders type setting card 1`] = `
     updateField={[MockFunction args.updateField]}
   />
   <TypeRow
-    key="3"
+    key="choiceresponse"
     label="Multi Select Problem"
     lastRow={false}
     selected={true}
@@ -38,7 +38,7 @@ exports[`TypeCard snapshot snapshot: renders type setting card 1`] = `
     updateField={[MockFunction args.updateField]}
   />
   <TypeRow
-    key="4"
+    key="multiplechoiceresponse"
     label="Single Select Problem"
     lastRow={true}
     selected={true}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -1,31 +1,31 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { injectIntl } from '@edx/frontend-platform/i18n';
 import { connect } from 'react-redux';
+import { Col, Container, Row } from '@edx/paragon';
 import AnswerWidget from './AnswerWidget';
 import SettingsWidget from './SettingsWidget';
 import QuestionWidget from './QuestionWidget';
 import { EditorContainer } from '../../../EditorContainer';
 import { selectors } from '../../../../data/redux';
-import { ReactStateSettingsParser } from '../../data/ReactStateSettingsParser';
-import { ReactStateOLXParser } from '../../data/ReactStateOLXParser';
-import { Col, Container, Row } from '@edx/paragon';
-
+import ReactStateSettingsParser from '../../data/ReactStateSettingsParser';
+import ReactStateOLXParser from '../../data/ReactStateOLXParser';
 
 export const EditProblemView = ({
   problemType,
   problemState,
 }) => {
-  const parseSate = (problemState) => () => {
-    const reactSettingsParser = new ReactStateSettingsParser(problemState);
-    const reactOLXParser = new ReactStateOLXParser({ problem: problemState });
+  const parseState = (problem) => () => {
+    const reactSettingsParser = new ReactStateSettingsParser(problem);
+    const reactOLXParser = new ReactStateOLXParser({ problem });
     return {
       settings: reactSettingsParser.getSettings(),
       olx: reactOLXParser.buildOLX(),
     };
   };
   return (
-    <EditorContainer getContent={parseSate(problemState)}>
+    <EditorContainer getContent={parseState(problemState)}>
       <Container fluid>
         <Row>
           <Col xs={9}>
@@ -39,6 +39,12 @@ export const EditProblemView = ({
       </Container>
     </EditorContainer>
   );
+};
+
+EditProblemView.propTypes = {
+  problemType: PropTypes.string.isRequired,
+  // eslint-disable-next-line
+  problemState: PropTypes.any.isRequired,
 };
 
 export const mapStateToProps = (state) => ({

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { injectIntl } from '@edx/frontend-platform/i18n';
 import { connect } from 'react-redux';
 import { Col, Container, Row } from '@edx/paragon';
 import AnswerWidget from './AnswerWidget';
@@ -52,4 +51,4 @@ export const mapStateToProps = (state) => ({
   problemState: selectors.problem.completeState(state),
 });
 
-export default injectIntl(connect(mapStateToProps)(EditProblemView));
+export default connect(mapStateToProps)(EditProblemView);

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.js
@@ -1,9 +1,7 @@
 import {
   useState,
 } from 'react';
-import { StrictDict } from '../../utils';
-
-import * as module from './hooks';
+import { StrictDict } from '../../../../utils';
 
 export const state = StrictDict({
   selected: (val) => useState(val),

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/index.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import ProblemTypeSelect from './content/ProblemTypeSelect';
 import Preview from './content/Preview';
 import SelectTypeWrapper from './SelectTypeWrapper';
+import * as hooks from './hooks';
 
-export const SelectTypeModal = ({
-  onClose,
-}) => {
+export const SelectTypeModal = () => {
   const { selected, setSelected } = hooks.state.selected(null);
 
   return (
@@ -20,10 +18,6 @@ export const SelectTypeModal = ({
       </SelectTypeWrapper>
     </div>
   );
-};
-
-SelectTypeModal.propTypes = {
-  onClose: PropTypes.func.isRequired,
 };
 
 export default SelectTypeModal;

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
@@ -2,7 +2,7 @@ import _ from 'lodash-es';
 import { XMLParser, XMLBuilder } from 'fast-xml-parser';
 import { ProblemTypeKeys } from '../../../data/constants/problem';
 
-export class ReactStateOLXParser {
+class ReactStateOLXParser {
   constructor(problemState) {
     const parserOptions = {
       ignoreAttributes: false,
@@ -267,3 +267,5 @@ export class ReactStateOLXParser {
     return problemString;
   }
 }
+
+export default ReactStateOLXParser;

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
@@ -1,5 +1,4 @@
 import { OLXParser } from './OLXParser';
-import { ReactStateOLXParser } from './ReactStateOLXParser';
 import {
   checkboxesOLXWithFeedbackAndHintsOLX,
   dropdownOLXWithFeedbackAndHintsOLX,
@@ -9,6 +8,7 @@ import {
   mutlipleChoiceWithFeedbackAndHintsOLX,
   textInputWithFeedbackAndHintsOLXWithMultipleAnswers,
 } from './mockData/olxTestData';
+import ReactStateOLXParser from './ReactStateOLXParser';
 
 describe('Check React Sate OLXParser problem', () => {
   test('Test checkbox with feedback and hints problem type', () => {

--- a/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.js
@@ -1,15 +1,15 @@
-import { popuplateItem } from "./SettingsParser";
+import { popuplateItem } from './SettingsParser';
 
-export class ReactStateSettingsParser {
+class ReactStateSettingsParser {
   constructor(problemState) {
     this.problemState = problemState;
   }
 
   getSettings() {
-    let settings = {}
-    const stateSettings = this.problemState.settings
+    let settings = {};
+    const stateSettings = this.problemState.settings;
 
-    settings = popuplateItem(settings, 'matLabApiKey', 'matlab_api_key', stateSettings)
+    settings = popuplateItem(settings, 'matLabApiKey', 'matlab_api_key', stateSettings);
     settings = popuplateItem(settings, 'number', 'max_attempts', stateSettings.scoring.attempts);
     settings = popuplateItem(settings, 'weight', 'weight', stateSettings.scoring);
     settings = popuplateItem(settings, 'on', 'showanswer', stateSettings.showAnswer);
@@ -19,5 +19,6 @@ export class ReactStateSettingsParser {
 
     return settings;
   }
-
 }
+
+export default ReactStateSettingsParser;

--- a/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.test.js
@@ -1,12 +1,12 @@
-import { ReactStateSettingsParser } from './ReactStateSettingsParser';
+import ReactStateSettingsParser from './ReactStateSettingsParser';
 import {
   checklistWithFeebackHints,
 } from './mockData/problemTestData';
 
-describe("Test State to Settings Parser", () => {
-  test("Test settings parsed from react state", () => {
+describe('Test State to Settings Parser', () => {
+  test('Test settings parsed from react state', () => {
     const settings = new ReactStateSettingsParser(checklistWithFeebackHints.state).getSettings();
-    const { markdown, ...settingsPayload } = checklistWithFeebackHints.metadata
+    const { markdown, ...settingsPayload } = checklistWithFeebackHints.metadata;
     expect(settings).toStrictEqual(settingsPayload);
   });
-})
+});

--- a/src/editors/containers/ProblemEditor/data/SettingsParser.js
+++ b/src/editors/containers/ProblemEditor/data/SettingsParser.js
@@ -1,66 +1,67 @@
 import _ from 'lodash-es';
 
-import { ShowAnswerTypes } from "../../../data/constants/problem";
+import { ShowAnswerTypes } from '../../../data/constants/problem';
 
 export const popuplateItem = (parentObject, itemName, statekey, metadata) => {
-    let item = _.get(metadata, itemName, null);
-    if (!_.isNil(item)) {
-        parentObject = { ...parentObject, [statekey]: item };
-    }
-    return parentObject;
-}
+  let parent = parentObject;
+  const item = _.get(metadata, itemName, null);
+  if (!_.isNil(item)) {
+    parent = { ...parentObject, [statekey]: item };
+  }
+  return parent;
+};
 
 export const parseScoringSettings = (metadata) => {
-    let scoring = {};
+  let scoring = {};
 
-    let attempts = popuplateItem({}, 'max_attempts', 'number', metadata);
-    if (!_.isEmpty(attempts)){
-        let unlimited = true;
-        if (attempts.number > 0) {
-            unlimited = false;
-        }
-        attempts = { ...attempts, unlimited: unlimited, };
-        scoring = { ...scoring, attempts };
+  let attempts = popuplateItem({}, 'max_attempts', 'number', metadata);
+  if (!_.isEmpty(attempts)) {
+    let unlimited = true;
+    if (attempts.number > 0) {
+      unlimited = false;
     }
+    attempts = { ...attempts, unlimited };
+    scoring = { ...scoring, attempts };
+  }
 
-    scoring = popuplateItem(scoring, 'weight', 'weight', metadata);
+  scoring = popuplateItem(scoring, 'weight', 'weight', metadata);
 
-    return scoring;
-}
+  return scoring;
+};
 
 export const parseShowAnswer = (metadata) => {
-    let showAnswer = {};
+  let showAnswer = {};
 
-    let showAnswerType = _.get(metadata, 'showanswer', {});
-    if (!_.isNil(showAnswerType) && showAnswerType in ShowAnswerTypes){
-        showAnswer = { ...showAnswer, ['on']: showAnswerType };
-    }
+  const showAnswerType = _.get(metadata, 'showanswer', {});
+  if (!_.isNil(showAnswerType) && showAnswerType in ShowAnswerTypes) {
+    showAnswer = { ...showAnswer, on: showAnswerType };
+  }
 
-    showAnswer = popuplateItem(showAnswer, 'attempts_before_showanswer_button', 'afterAttempts', metadata)
+  showAnswer = popuplateItem(showAnswer, 'attempts_before_showanswer_button', 'afterAttempts', metadata);
 
-    return showAnswer;
-}
+  return showAnswer;
+};
 
 export const parseSettings = (metadata) => {
-    let settings = {};
-    
-    if (_.isNil(metadata) || _.isEmpty(metadata)){
-        return settings;
-    }
+  let settings = {};
 
-    settings = popuplateItem(settings, 'matlab_api_key', 'matLabApiKey', metadata);
-
-    let scoring = parseScoringSettings(metadata);
-    if (!_.isEmpty(scoring)){
-        settings = { ...settings, scoring };
-    }
-
-    let showAnswer = parseShowAnswer(metadata);
-    if (!_.isEmpty(showAnswer)){
-        settings = { ...settings, showAnswer }
-    }
-    settings = popuplateItem(settings, 'show_reset_button', 'showResetButton', metadata);
-    settings = popuplateItem(settings, 'submission_wait_seconds', 'timeBetween', metadata);
-
+  if (_.isNil(metadata) || _.isEmpty(metadata)) {
     return settings;
-}
+  }
+
+  settings = popuplateItem(settings, 'matlab_api_key', 'matLabApiKey', metadata);
+
+  const scoring = parseScoringSettings(metadata);
+  if (!_.isEmpty(scoring)) {
+    settings = { ...settings, scoring };
+  }
+
+  const showAnswer = parseShowAnswer(metadata);
+  if (!_.isEmpty(showAnswer)) {
+    settings = { ...settings, showAnswer };
+  }
+  settings = popuplateItem(settings, 'show_reset_button', 'showResetButton', metadata);
+  settings = popuplateItem(settings, 'submission_wait_seconds', 'timeBetween', metadata);
+
+  return settings;
+};

--- a/src/editors/containers/ProblemEditor/data/SettingsParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/SettingsParser.test.js
@@ -1,68 +1,69 @@
-import { parseScoringSettings, parseSettings, parseShowAnswer } from "./SettingsParser";
-import { checklistWithFeebackHints,
-         dropdownWithFeedbackHints,
-         numericWithHints,
-         textInputWithHints,
-         sigleSelectWithHints } from "./mockData/problemTestData";
+import { parseScoringSettings, parseSettings, parseShowAnswer } from './SettingsParser';
+import {
+  checklistWithFeebackHints,
+  dropdownWithFeedbackHints,
+  numericWithHints,
+  textInputWithHints,
+  sigleSelectWithHints,
+} from './mockData/problemTestData';
 
-
-describe("Test Settings to State Parser", () => {
-  test("Test all fields populated", () => {
+describe('Test Settings to State Parser', () => {
+  test('Test all fields populated', () => {
     const settings = parseSettings(checklistWithFeebackHints.metadata);
-    const { hints, ...settingsPayload } = checklistWithFeebackHints.state.settings
+    const { hints, ...settingsPayload } = checklistWithFeebackHints.state.settings;
     expect(settings).toStrictEqual(settingsPayload);
   });
-  
-  test("Test partial fields populated", () => {
+
+  test('Test partial fields populated', () => {
     const settings = parseSettings(dropdownWithFeedbackHints.metadata);
-    const { hints, ...settingsPayload } = dropdownWithFeedbackHints.state.settings
+    const { hints, ...settingsPayload } = dropdownWithFeedbackHints.state.settings;
     expect(settings).not.toStrictEqual(settingsPayload);
-    const { randomization, matLabApiKey, ...settingsPayloadPartial } = settingsPayload
+    const { randomization, matLabApiKey, ...settingsPayloadPartial } = settingsPayload;
     expect(settings).toStrictEqual(settingsPayloadPartial);
   });
 
-  test("Test score settings", () => {
+  test('Test score settings', () => {
     const scoreSettings = parseScoringSettings(checklistWithFeebackHints.metadata);
     expect(scoreSettings).toStrictEqual(checklistWithFeebackHints.state.settings.scoring);
   });
 
-  test("Test score settings zero attempts", () => {
+  test('Test score settings zero attempts', () => {
     const scoreSettings = parseScoringSettings(numericWithHints.metadata);
     expect(scoreSettings).toStrictEqual(numericWithHints.state.settings.scoring);
   });
 
-  test("Test score settings attempts missing", () => {
+  test('Test score settings attempts missing', () => {
     const scoreSettings = parseScoringSettings(textInputWithHints.metadata);
     expect(scoreSettings.attempts).toBeUndefined();
   });
 
-  test("Test score settings missing", () => {
+  test('Test score settings missing', () => {
     const settings = parseSettings(sigleSelectWithHints.metadata);
     expect(settings.scoring).toBeUndefined();
   });
 
-  test("Test invalid randomization", () => {
+  test('Test invalid randomization', () => {
     const settings = parseSettings(numericWithHints.metadata);
     expect(settings.randomization).toBeUndefined();
   });
 
-  test("Test invalid show answer", () => {
+  test('Test invalid show answer', () => {
     const showAnswerSettings = parseShowAnswer(numericWithHints.metadata);
     expect(showAnswerSettings.on).toBeUndefined();
   });
 
-  test("Test show answer settings missing", () => {
+  test('Test show answer settings missing', () => {
     const settings = parseShowAnswer(textInputWithHints.metadata);
     expect(settings.showAnswer).toBeUndefined();
   });
 
-  test("Test empty metadata", () => {
+  test('Test empty metadata', () => {
     const scoreSettings = parseSettings({});
     expect(scoreSettings).toStrictEqual({});
   });
 
-  test("Test null metadata", () => {
+  test('Test null metadata', () => {
     const scoreSettings = parseSettings(null);
     expect(scoreSettings).toStrictEqual({});
   });
-})
+});

--- a/src/editors/containers/ProblemEditor/data/mockData/problemTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/problemTestData.js
@@ -72,7 +72,6 @@ export const checklistWithFeebackHints = {
           number: 5,
         },
       },
-      randomization: 'per_student',
       timeBetween: 3,
       matLabApiKey: 'sample_matlab_api_key',
       showAnswer: {
@@ -97,7 +96,6 @@ export const checklistWithFeebackHints = {
 `,
     matlab_api_key: 'sample_matlab_api_key',
     max_attempts: 5,
-    rerandomize: 'per_student',
     show_reset_button: true,
     showanswer: 'after_attempts',
     attempts_before_showanswer_button: 2,
@@ -150,7 +148,6 @@ export const dropdownWithFeedbackHints = {
           number: 5,
         },
       },
-      randomization: 'never',
       timeBetween: 3,
       matLabApiKey: '',
       showAnswer: {
@@ -224,7 +221,6 @@ export const numericWithHints = {
           number: 0,
         },
       },
-      randomization: 'per_student',
       timeBetween: 0,
       matLabApiKey: '',
       showAnswer: {
@@ -296,7 +292,6 @@ export const textInputWithHints = {
           number: 0,
         },
       },
-      randomization: '',
       timeBetween: 0,
       matLabApiKey: '',
       showAnswer: {
@@ -370,7 +365,6 @@ export const sigleSelectWithHints = {
           number: 0,
         },
       },
-      randomization: '',
       timeBetween: 0,
       matLabApiKey: '',
       showAnswer: {

--- a/src/editors/containers/ProblemEditor/data/mockData/problemTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/problemTestData.js
@@ -9,78 +9,78 @@ export const checklistWithFeebackHints = {
         title: 'a correct answer',
         correct: true,
         selectedFeedback: ' You can specify optional feedback that appears after the learner selects and submits this answer.',
-        unselectedFeedback: 'You can specify optional feedback that appears after the learner clears and submits this answer.'
+        unselectedFeedback: 'You can specify optional feedback that appears after the learner clears and submits this answer.',
       },
       {
         id: 'B',
         title: 'an incorrect answer',
         correct: false,
         selectedFeedback: '',
-        unselectedFeedback: ''
+        unselectedFeedback: '',
       },
       {
         id: 'C',
         title: 'an incorrect answer',
         correct: false,
         selectedFeedback: ' You can specify optional feedback for none, all, or a subset of the answers.',
-        unselectedFeedback: 'You can specify optional feedback for selected answers, cleared answers, or both.'
+        unselectedFeedback: 'You can specify optional feedback for selected answers, cleared answers, or both.',
       },
       {
         id: 'D',
         title: 'a correct answer',
         correct: true,
         selectedFeedback: '',
-        unselectedFeedback: ''
-      }
+        unselectedFeedback: '',
+      },
     ],
     groupFeedbackList: [
       {
         id: 3,
         answers: [
-          "A",
-          "B",
-          "D"
+          'A',
+          'B',
+          'D',
         ],
-        feedback: 'You can specify optional feedback for a combination of answers which appears after the specified set of answers is submitted.'
+        feedback: 'You can specify optional feedback for a combination of answers which appears after the specified set of answers is submitted.',
       },
       {
         id: 4,
         answers: [
-          "A",
-          "B",
-          "C",
-          "D"
+          'A',
+          'B',
+          'C',
+          'D',
         ],
-        feedback: 'You can specify optional feedback for one, several, or all answer combinations.'
-      }
+        feedback: 'You can specify optional feedback for one, several, or all answer combinations.',
+      },
     ],
     settings: {
       hints: [
         {
           id: 14,
-          value: 'You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.'
+          value: 'You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.',
         },
         {
           id: 15,
-          value: 'If you add more than one hint, a different hint appears each time learners select the hint button.'
-        }
+          value: 'If you add more than one hint, a different hint appears each time learners select the hint button.',
+        },
       ],
       scoring: {
         weight: 2.5,
         attempts: {
           unlimited: false,
-          number: 5
-        }
+          number: 5,
+        },
       },
       randomization: 'per_student',
       timeBetween: 3,
       matLabApiKey: 'sample_matlab_api_key',
       showAnswer: {
         on: 'after_attempts',
-        afterAttempts: 2
+        afterAttempts: 2,
       },
-      showResetButton: true
-    }
+      showResetButton: true,
+    },
   },
   metadata: {
     markdown: `You can use this template as a guide to the simple editor markdown and OLX markup to use for checkboxes with hints and feedback problems. Edit this component to replace this template with your own assessment.
@@ -103,7 +103,7 @@ export const checklistWithFeebackHints = {
     attempts_before_showanswer_button: 2,
     submission_wait_seconds: 3,
     weight: 2.5,
-  }
+  },
 };
 
 export const dropdownWithFeedbackHints = {
@@ -116,32 +116,32 @@ export const dropdownWithFeedbackHints = {
         id: 'A',
         title: 'an incorrect answer',
         correct: false,
-        feedback: 'You can specify optional feedback like this, which appears after this answer is submitted.'
+        feedback: 'You can specify optional feedback like this, which appears after this answer is submitted.',
       },
       {
         id: 'B',
         title: 'the correct answer',
         correct: true,
-        feedback: ''
+        feedback: '',
       },
       {
         id: 'C',
         title: 'an incorrect answer',
         correct: false,
-        feedback: 'You can specify optional feedback for none, a subset, or all of the answers.'
-      }
+        feedback: 'You can specify optional feedback for none, a subset, or all of the answers.',
+      },
     ],
     groupFeedbackList: [],
     settings: {
       hints: [
         {
           id: 8,
-          value: 'You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.'
+          value: 'You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.',
         },
         {
           id: 9,
-          value: 'If you add more than one hint, a different hint appears each time learners select the hint button.'
-        }
+          value: 'If you add more than one hint, a different hint appears each time learners select the hint button.',
+        },
       ],
       scoring: {
         weight: 2.5,
@@ -158,7 +158,7 @@ export const dropdownWithFeedbackHints = {
         afterAttempts: 2,
       },
       showResetButton: true,
-    }
+    },
   },
   metadata: {
     markdown: `You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown with hints and feedback problems. Edit this component to replace this template with your own assessment.
@@ -177,8 +177,8 @@ export const dropdownWithFeedbackHints = {
     attempts_before_showanswer_button: 2,
     submission_wait_seconds: 3,
     weight: 2.5,
-  }
-}
+  },
+};
 
 export const numericWithHints = {
   state: {
@@ -190,49 +190,49 @@ export const numericWithHints = {
         id: 'A',
         title: '100 +-5',
         feedback: 'You can specify optional feedback like this, which appears after this answer is submitted.',
-        correct: true
+        correct: true,
       },
       {
         id: 'B',
         title: '90 +-5',
         feedback: 'You can specify optional feedback like this, which appears after this answer is submitted.',
-        correct: true
+        correct: true,
       },
       {
         id: 'C',
         title: '60 +-5',
         feedback: 'You can specify optional feedback like this, which appears after this answer is submitted.',
-        correct: false
-      }
+        correct: false,
+      },
     ],
     groupFeedbackList: [],
     settings: {
       hints: [
         {
           id: 6,
-          value: 'You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.'
+          value: 'You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.',
         },
         {
           id: 7,
-          value: 'If you add more than one hint, a different hint appears each time learners select the hint button.'
-        }
+          value: 'If you add more than one hint, a different hint appears each time learners select the hint button.',
+        },
       ],
       scoring: {
         weight: 2.5,
         attempts: {
           unlimited: true,
-          number: 0
-        }
+          number: 0,
+        },
       },
       randomization: 'per_student',
       timeBetween: 0,
       matLabApiKey: '',
       showAnswer: {
         on: 'after_attempts',
-        afterAttempts: 1
+        afterAttempts: 1,
       },
-      showResetButton: false
-    }
+      showResetButton: false,
+    },
   },
   metadata: {
     markdown: `You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.
@@ -249,8 +249,8 @@ not=60 +-5 {{You can specify optional feedback like this, which appears after th
     rerandomize: 'invalid_input',
     showanswer: 'invalid_input',
     attempts_before_showanswer_button: 2,
-  }
-}
+  },
+};
 
 export const textInputWithHints = {
   state: {
@@ -262,49 +262,49 @@ export const textInputWithHints = {
         id: 'A',
         title: 'the correct answer',
         feedback: 'You can specify optional feedback like this, which appears after this answer is submitted.',
-        correct: true
+        correct: true,
       },
       {
         id: 'B',
         title: 'optional acceptable variant of the correct answer',
         feedback: '',
-        correct: true
+        correct: true,
       },
       {
         id: 'C',
         title: 'optional incorrect answer such as a frequent misconception',
         feedback: 'You can specify optional feedback for none, a subset, or all of the answers.',
-        correct: false
-      }
+        correct: false,
+      },
     ],
     groupFeedbackList: [],
     settings: {
       hints: [
         {
           id: 9,
-          value: 'You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.'
+          value: 'You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.',
         },
         {
           id: 10,
-          value: 'If you add more than one hint, a different hint appears each time learners select the hint button.'
-        }
+          value: 'If you add more than one hint, a different hint appears each time learners select the hint button.',
+        },
       ],
       scoring: {
         weight: 2.5,
         attempts: {
           unlimited: true,
-          number: 0
-        }
+          number: 0,
+        },
       },
       randomization: '',
       timeBetween: 0,
       matLabApiKey: '',
       showAnswer: {
         on: '',
-        afterAttempts: 1
+        afterAttempts: 1,
       },
-      showResetButton: false
-    }
+      showResetButton: false,
+    },
   },
   metadata: {
     markdown: `You can use this template as a guide to the simple editor markdown and OLX markup to use for text input with hints and feedback problems. Edit this component to replace this template with your own assessment.
@@ -317,8 +317,8 @@ not=optional incorrect answer such as a frequent misconception {{You can specify
 ||If you add more than one hint, a different hint appears each time learners select the hint button.||
 `,
     weight: 2.5,
-  }
-}
+  },
+};
 
 export const sigleSelectWithHints = {
   state: {
@@ -330,55 +330,55 @@ export const sigleSelectWithHints = {
         id: 'A',
         title: 'a correct answer',
         correct: true,
-        feedback: 'Some new feedback'
+        feedback: 'Some new feedback',
       },
       {
         id: 'B',
         title: 'an incorrect answer',
         correct: false,
-        feedback: ''
+        feedback: '',
       },
       {
         id: 'C',
         title: 'an incorrect answer',
         correct: false,
-        feedback: 'Wrong feedback'
+        feedback: 'Wrong feedback',
       },
       {
         id: 'D',
         title: 'an incorrect answer again',
         correct: false,
-        feedback: ''
-      }
+        feedback: '',
+      },
     ],
     groupFeedbackList: [],
     settings: {
       hints: [
         {
           id: 13,
-          value: 'You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.'
+          value: 'You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.',
         },
         {
           id: 14,
-          value: 'If you add more than one hint, a different hint appears each time learners select the hint button.'
-        }
+          value: 'If you add more than one hint, a different hint appears each time learners select the hint button.',
+        },
       ],
       scoring: {
         weight: 0,
         attempts: {
           unlimited: true,
-          number: 0
-        }
+          number: 0,
+        },
       },
       randomization: '',
       timeBetween: 0,
       matLabApiKey: '',
       showAnswer: {
         on: '',
-        afterAttempts: 1
+        afterAttempts: 1,
       },
-      showResetButton: false
-    }
+      showResetButton: false,
+    },
   },
   metadata: {
     markdown: `You can use this template as a guide to the simple editor markdown and OLX markup to use for checkboxes with hints and feedback problems. Edit this component to replace this template with your own assessment.
@@ -390,6 +390,6 @@ export const sigleSelectWithHints = {
 ( ) an incorrect answer again
 ||You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.||
 ||If you add more than one hint, a different hint appears each time learners select the hint button.||
-`
-  }
-}
+`,
+  },
+};

--- a/src/editors/containers/TextEditor/index.jsx
+++ b/src/editors/containers/TextEditor/index.jsx
@@ -53,6 +53,7 @@ export const TextEditor = ({
 
   if (!refReady) { return null; }
 
+  // eslint-disable-next-line
   console.log(`This is a Raw Editor: ${isRaw}`);
 
   return (
@@ -103,6 +104,7 @@ export const TextEditor = ({
 };
 TextEditor.defaultProps = {
   blockValue: null,
+  isRaw: false,
   lmsEndpointUrl: null,
   studioEndpointUrl: null,
 };
@@ -112,6 +114,7 @@ TextEditor.propTypes = {
   blockValue: PropTypes.shape({
     data: PropTypes.shape({ data: PropTypes.string }),
   }),
+  isRaw: PropTypes.bool,
   lmsEndpointUrl: PropTypes.string,
   studioEndpointUrl: PropTypes.string,
   blockFailed: PropTypes.bool.isRequired,

--- a/src/editors/containers/TextEditor/index.test.jsx
+++ b/src/editors/containers/TextEditor/index.test.jsx
@@ -62,6 +62,7 @@ jest.mock('../../data/redux', () => ({
       blockValue: jest.fn(state => ({ blockValue: state })),
       lmsEndpointUrl: jest.fn(state => ({ lmsEndpointUrl: state })),
       studioEndpointUrl: jest.fn(state => ({ lmsEndpointUrl: state })),
+      isRaw: jest.fn(state => ({ isRaw: state })),
     },
     requests: {
       isFailed: jest.fn((state, params) => ({ isFailed: { state, params } })),
@@ -79,6 +80,7 @@ describe('TextEditor', () => {
     studioEndpointUrl: 'sOmEoThERvaLue.cOm',
     blockFailed: false,
     blockFinished: true,
+    isRaw: false,
     initializeEditor: jest.fn().mockName('args.intializeEditor'),
     // inject
     intl: { formatMessage },

--- a/src/editors/data/redux/app/selectors.js
+++ b/src/editors/data/redux/app/selectors.js
@@ -40,14 +40,13 @@ export const isInitialized = createSelector(
 
 export const isRaw = createSelector([module.simpleSelectors.studioView],
   (studioView) => {
+    let editorIsRaw = false;
     if (studioView === null) {
-      return null;
+      editorIsRaw = false;
+    } else if (studioView.data.html.includes('data-editor="raw"')) {
+      editorIsRaw = true;
     }
-    console.log(studioView.data.html);
-    if (studioView.data.html.includes('data-editor="raw"')) {
-      return true;
-    }
-    return false;
+    return editorIsRaw;
   });
 
 export const displayTitle = createSelector(

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -45,10 +45,8 @@ const problem = createSlice({
       question: payload,
     }),
     updateAnswer: (state, { payload }) => {
-      // you can mutuate state only inside creating
-      // https://redux-toolkit.js.org/usage/immer-reducers#immutable-updates-with-immer
       const { id, hasSingleAnswer, ...answer } = payload;
-      state.answers = state.answers.map(obj => {
+      const answers = state.answers.map(obj => {
         if (obj.id === id) {
           return { ...obj, ...answer };
         }
@@ -59,19 +57,27 @@ const problem = createSlice({
         }
         return obj;
       });
+      return {
+        ...state,
+        answers,
+      };
     },
     deleteAnswer: (state, { payload }) => {
       const { id } = payload;
       if (state.answers.length <= 1) {
         return state;
       }
-      state.answers = state.answers.filter(obj => obj.id !== id).map((answer, index) => {
+      const answers = state.answers.filter(obj => obj.id !== id).map((answer, index) => {
         const newId = indexToLetterMap[index];
         if (answer.id === newId) {
           return answer;
         }
         return { ...answer, id: newId };
       });
+      return {
+        ...state,
+        answers,
+      };
     },
     addAnswer: (state) => {
       const currAnswers = state.answers;
@@ -92,25 +98,29 @@ const problem = createSlice({
       } else {
         newOption.feedback = '';
       }
-      state.answers = [
+      const answers = [
         ...currAnswers,
         newOption,
       ];
+      return {
+        ...state,
+        answers,
+      };
     },
-    updateSettings: (state, {payload}) => ({
+    updateSettings: (state, { payload }) => ({
       ...state,
       settings: {
         ...state.settings,
-        ...payload
-      }
+        ...payload,
+      },
     }),
-    load: (state, { payload: { settings: {scoring, showAnswer, ...settings}, ...payload } }) => ({
+    load: (state, { payload: { settings: { scoring, showAnswer, ...settings }, ...payload } }) => ({
       ...state,
       settings: {
         ...state.settings,
         scoring: { ...state.settings.scoring, ...scoring },
         showAnswer: { ...state.settings.showAnswer, ...showAnswer },
-        ...settings
+        ...settings,
       },
       ...payload,
     }),

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -5,12 +5,17 @@ import { parseSettings } from '../../../containers/ProblemEditor/data/SettingsPa
 
 export const initializeProblem = (blockValue) => (dispatch) => {
   const rawOLX = _.get(blockValue, 'data.data', {});
-  const olxParser = new OLXParser(rawOLX);
-  const { ...data } = olxParser.getParsedOLXData();
-  let { settings } = olxParser.getParsedOLXData();
-  settings = { ...settings, ...parseSettings(_.get(blockValue, 'data.metadata', {})) };
-  if (!_.isEmpty(rawOLX) && !_.isEmpty(data)) {
-    dispatch(actions.problem.load({ ...data, rawOLX, settings }));
+  try {
+    const olxParser = new OLXParser(rawOLX);
+    const { ...data } = olxParser.getParsedOLXData();
+    let { settings } = olxParser.getParsedOLXData();
+    settings = { ...settings, ...parseSettings(_.get(blockValue, 'data.metadata', {})) };
+    if (!_.isEmpty(rawOLX) && !_.isEmpty(data)) {
+      dispatch(actions.problem.load({ ...data, rawOLX, settings }));
+    }
+  } catch (error) {
+    // eslint-disable-next-line
+    console.error(error);
   }
 };
 

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -6,8 +6,9 @@ import { parseSettings } from '../../../containers/ProblemEditor/data/SettingsPa
 export const initializeProblem = (blockValue) => (dispatch) => {
   const rawOLX = _.get(blockValue, 'data.data', {});
   const olxParser = new OLXParser(rawOLX);
-  let { settings, ...data } = olxParser.getParsedOLXData();
-  settings = { ...settings, ...parseSettings(_.get(blockValue, 'data.metadata', {})) }
+  const { ...data } = olxParser.getParsedOLXData();
+  let { settings } = olxParser.getParsedOLXData();
+  settings = { ...settings, ...parseSettings(_.get(blockValue, 'data.metadata', {})) };
   if (!_.isEmpty(rawOLX) && !_.isEmpty(data)) {
     dispatch(actions.problem.load({ ...data, rawOLX, settings }));
   }

--- a/src/editors/data/services/cms/mockApi.js
+++ b/src/editors/data/services/cms/mockApi.js
@@ -38,17 +38,17 @@ export const fetchBlockById = ({ blockId, studioEndpointUrl }) => {
         an incorrect answer
         ]]`,
         attempts_before_showanswer_button: 7,
-        matlab_api_key: "sample_matlab_api_key",
+        matlab_api_key: 'sample_matlab_api_key',
         max_attempts: 5,
-        rerandomize: "per_student",
+        rerandomize: 'per_student',
         show_reset_button: true,
-        showanswer: "after_attempts",
+        showanswer: 'after_attempts',
         submission_wait_seconds: 15,
         weight: 29,
       },
     };
   }
-  return mockPromise({ data: { ...data }, });
+  return mockPromise({ data: { ...data } });
 };
 
 // TODO: update to return block data appropriate per block ID, which will equal block type
@@ -132,7 +132,7 @@ export const normalizeContent = ({
       couseKey: learningContextId,
       has_changes: true,
       id: blockId,
-      metadata: { display_name: title,  ...content.settings },
+      metadata: { display_name: title, ...content.settings },
     };
   } else {
     throw new TypeError(`No Block in V2 Editors named /"${blockType}/", Cannot Save Content.`);
@@ -213,11 +213,11 @@ export const fetchStudioView = ({ blockId, studioEndpointUrl }) => {
         an incorrect answer
         ]]`,
         attempts_before_showanswer_button: 7,
-        matlab_api_key: "numerical_input_matlab_api_key",
+        matlab_api_key: 'numerical_input_matlab_api_key',
         max_attempts: 5,
-        rerandomize: "per_student",
+        rerandomize: 'per_student',
         show_reset_button: true,
-        showanswer: "after_attempts",
+        showanswer: 'after_attempts',
         submission_wait_seconds: 15,
         weight: 29,
       },

--- a/src/editors/data/services/cms/mockApi.js
+++ b/src/editors/data/services/cms/mockApi.js
@@ -40,7 +40,6 @@ export const fetchBlockById = ({ blockId, studioEndpointUrl }) => {
         attempts_before_showanswer_button: 7,
         matlab_api_key: 'sample_matlab_api_key',
         max_attempts: 5,
-        rerandomize: 'per_student',
         show_reset_button: true,
         showanswer: 'after_attempts',
         submission_wait_seconds: 15,

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -21,10 +21,12 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-intl": "^5.24.6",
+        "react-redux": "^7.1.1",
         "regenerator-runtime": "^0.13.9"
       }
     },
     "..": {
+      "name": "@edx/frontend-lib-content-components",
       "version": "1.0.0-semantically-released",
       "license": "AGPL-3.0",
       "dependencies": {
@@ -3752,7 +3754,6 @@
       "version": "7.1.24",
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
       "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
-      "peer": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -16651,7 +16652,6 @@
       "version": "7.2.9",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
       "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -17001,7 +17001,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
       "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -23544,7 +23543,6 @@
       "version": "7.1.24",
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
       "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
-      "peer": true,
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -33090,7 +33088,6 @@
       "version": "7.2.9",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
       "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -33337,7 +33334,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
       "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.9.2"
       }

--- a/www/package.json
+++ b/www/package.json
@@ -10,11 +10,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@edx/browserslist-config": "1.0.0",
     "@edx/brand": "npm:@edx/brand-edx.org@^2.0.3",
+    "@edx/browserslist-config": "1.0.0",
     "@edx/frontend-build": "^11.0.0",
-    "@edx/frontend-platform": "2.5.1",
     "@edx/frontend-lib-content-components": "file:..",
+    "@edx/frontend-platform": "2.5.1",
     "@edx/paragon": "20.13.0",
     "core-js": "^3.21.1",
     "dotenv": "^16.0.0",
@@ -22,6 +22,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-intl": "^5.24.6",
+    "react-redux": "^7.1.1",
     "regenerator-runtime": "^0.13.9"
   }
 }


### PR DESCRIPTION
The PR resolve the lint issues and tries to fix all the possible related tests in [Main PR](https://github.com/openedx/frontend-lib-content-components/pull/110)

**JIRA tickets**: [BB-6950](https://tasks.opencraft.com/browse/BB-6950)

~~**Discussions**: Link to any public dicussions about this PR or the design/architecture. Otherwise omit this.~~

**Dependencies**: None

**Screenshots**: Always include screenshots if there is any change to the UI.

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.

**Testing instructions**:

- `npm test`
- `npm run lint`

Test related to upstream is failing -- app thunkActions › initialize › dispatches actions.app.initialize, and then fetches both block and unit